### PR TITLE
Reduce Resource Usage for UniformPowerOfTwo correctness

### DIFF
--- a/Guidelines.md
+++ b/Guidelines.md
@@ -5,14 +5,15 @@ Following are guidelines that one should follow unless there is a good technical
     * subset and new types.
     * covariance and contraviance.
     * Induction-recursion datatypes.
-    
+
 * Even if a function is not meant to be part of the compiled code, don't use ghost unless necessary.
 * Do not attach postconditions to functions. Instead, prove the postcondition as a separate lemma.
 * Make functions opaque.
 * Name preconditions of lemmas and reveal them only when necessary.
 * Be mindful of resource usage and refine your proof until it is less than 1M.
+* In particular, avoid `{:vcs_split_on_every_assert}` as this can increase the verification time a lot.
 * Keep proofs short and modular, as for a pencil and paper proof.
-* Prefer structured proofs in natural deduction rathen than sequences of assertions. 
+* Prefer structured proofs in natural deduction rathen than sequences of assertions.
 * Unless it is logically or mathematically necessary:
 <table>
    <tr>
@@ -20,44 +21,44 @@ Following are guidelines that one should follow unless there is a good technical
    </tr>
    <tr> </tr>
    <tr>
-      <td> 
+      <td>
 <pre>
 lemma Foo()
   ensures forall x: nat :: P(x)
 </pre>
-      </td> 
-      <td> 
+      </td>
+      <td>
 <pre>
-lemma Foo(x:nat) 
+lemma Foo(x:nat)
   ensures P(x)
 </pre>
       </td>
    </tr>
    <tr> </tr>
    <tr>
-      <td> 
+      <td>
 <pre>
 lemma Foo()
   ensures A ==> B
 </pre>
-      </td> 
-      <td> 
+      </td>
+      <td>
 <pre>
 lemma Foo()
   requires A
   ensures B
 </pre>
       </td>
-   </tr>  
+   </tr>
    <tr> </tr>
    <tr>
-      <td> 
+      <td>
 <pre>
 lemma Foo()
   ensures A /\ B
 </pre>
-      </td> 
-      <td> 
+      </td>
+      <td>
 <pre>
 lemma Foo1()
   ensures A
@@ -66,16 +67,16 @@ lemma Foo2()
   ensures B
 </pre>
       </td>
-   </tr> 
+   </tr>
    <tr> </tr>
    <tr>
-      <td> 
+      <td>
 <pre>
 lemma Foo()
   ensures A <==> B
 </pre>
-      </td> 
-      <td> 
+      </td>
+      <td>
 <pre>
 lemma Foo1()
   requires A
@@ -86,32 +87,32 @@ lemma Foo2()
   ensures A
 </pre>
       </td>
-   </tr> 
+   </tr>
    <tr> </tr>
    <tr>
-      <td> 
+      <td>
 <pre>
 lemma Foo()
   ensures exists x: T :: P(x)
 </pre>
-      </td> 
-      <td> 
+      </td>
+      <td>
 <pre>
 lemma Foo() returns (x: T)
   ensures P(x)
 </pre>
       </td>
-   </tr> 
+   </tr>
    <tr> </tr>
    <tr>
-      <td> 
+      <td>
 <pre>
 lemma Foo()
   requires A /\ B
   ensures C
 </pre>
-      </td> 
-      <td> 
+      </td>
+      <td>
 <pre>
 lemma Foo()
   requires A
@@ -119,17 +120,17 @@ lemma Foo()
   ensures C
 </pre>
       </td>
-   </tr> 
+   </tr>
    <tr> </tr>
    <tr>
-      <td> 
+      <td>
 <pre>
 lemma Foo()
   requires A \/ B
   ensures C
 </pre>
-      </td> 
-      <td> 
+      </td>
+      <td>
 <pre>
 lemma Foo1()
   requires A
@@ -137,10 +138,10 @@ lemma Foo1()
    <br>
 lemma Foo2()
   requires B
-  ensures C   
+  ensures C
 </pre>
       </td>
-   </tr> 
+   </tr>
 </table>
 * Establish preconditions of assertion in a by clause. For example, consider lemma Foo() requires A ensures B
 <table>
@@ -149,13 +150,13 @@ lemma Foo2()
    </tr>
    <tr> </tr>
    <tr>
-      <td> 
+      <td>
 <pre>
 assert A;
 Foo();
 </pre>
-      </td> 
-      <td> 
+      </td>
+      <td>
 <pre>
 assert B by {
   assert A;
@@ -163,7 +164,7 @@ assert B by {
 }
 </pre>
       </td>
-   </tr> 
+   </tr>
 </table>
 
 
@@ -174,6 +175,6 @@ assert B by {
 
 
 
-  
+
 
 

--- a/src/Distributions/UniformPowerOfTwo/Model.dfy
+++ b/src/Distributions/UniformPowerOfTwo/Model.dfy
@@ -16,16 +16,16 @@ module UniformPowerOfTwoModel {
   import opened Independence
   import opened WhileAndUntil
 
+  function UnifStep(m: nat): Hurd<nat> {
+    Bind(Deconstruct, (b: bool) => Return(if b then 2*m + 1 else 2*m))
+  }
+
   // Definition 48
   function ProbUnif(n: nat): (h: Hurd<nat>) {
     if n == 0 then
       Return(0)
     else
-      var f := (m: nat) =>
-                  var g := (b: bool) =>
-                            Return(if b then 2*m + 1 else 2*m);
-                  Bind(Deconstruct, g);
-      Bind(ProbUnif(n/2), f)
+      Bind(ProbUnif(n/2), UnifStep)
   }
 
   lemma {:axiom} ProbUnifTerminates(n: nat)

--- a/src/Math/Helper.dfy
+++ b/src/Math/Helper.dfy
@@ -132,7 +132,8 @@ module Helper {
   }
 
   lemma MultiplicationSubstitute(x: real, a: real, b: real)
-    ensures a == b ==> (a * x == b * x)
+    requires a == b
+    ensures a * x == b * x
   {}
 
   lemma DivisionByTwo(x: real)

--- a/src/Math/Helper.dfy
+++ b/src/Math/Helper.dfy
@@ -136,6 +136,13 @@ module Helper {
     ensures a * x == b * x
   {}
 
+  lemma InverseSubstitute(x: real, y: real)
+    requires x != 0.0
+    requires y != 0.0
+    requires x == y
+    ensures 1.0 / x == 1.0 / y
+  {}
+
   lemma DivisionByTwo(x: real)
     ensures 0.5 * x == x / 2.0
   {}
@@ -273,5 +280,15 @@ module Helper {
   lemma AdditionOfFractions(x: real, y: real, z: real)
     requires z != 0.0
     ensures (x / z) + (y / z) == (x + y) / z
+  {}
+
+  lemma DivDivToDivMul(x: real, y: real, z: real)
+    requires y != 0.0
+    requires z != 0.0
+    ensures (x / y) / z == x / (y * z)
+  {}
+
+  lemma NatMulNatToReal(x: nat, y: nat)
+    ensures (x * y) as real == (x as real) * (y as real)
   {}
 }

--- a/src/Math/Helper.dfy
+++ b/src/Math/Helper.dfy
@@ -5,7 +5,7 @@
 
 module Helper {
   /************
-   Definitions  
+   Definitions
   ************/
 
   function Abs(x: real): real {
@@ -40,7 +40,7 @@ module Helper {
     ensures pow == 1 ==> log == 0
     ensures pow > 1 ==> log > 0
   // {
-  //   if pow < base then 
+  //   if pow < base then
   //     0
   //   else
   //     DivDecreases(pow, base);
@@ -50,7 +50,7 @@ module Helper {
   // }
 
   /*******
-   Lemmas  
+   Lemmas
   *******/
 
   lemma LemmaAboutNatDivision(a: nat, b: nat)
@@ -84,6 +84,52 @@ module Helper {
     requires x != 0.0
     ensures a / x == b / x
   {}
+
+  lemma SmallDivMod(n: nat, m: nat)
+    requires m > 0
+    requires n < m
+    ensures n / m == 0
+    ensures n % m == n
+  {}
+
+  lemma DivModAddDenominator(n: nat, m: nat)
+    requires m > 0
+    ensures (n + m) / m == n / m + 1
+    ensures (n + m) % m == n % m
+  {
+    var zp := (n + m) / m - n / m - 1;
+    assert 0 == m * zp + ((n + m) % m) - (n % m);
+  }
+
+  lemma DivModIsUnique(n: nat, m: nat, a: nat, b: nat)
+    requires m > 0
+    requires b < m
+    requires n == a * m + b
+    ensures a == n / m
+    ensures b == n % m
+  {
+    if a == 0 {
+      assert n == b;
+    } else {
+      assert (n - m) / m == a - 1 && (n - m) % m == b by { DivModIsUnique(n - m, m, a - 1, b); }
+      assert n / m == a && n % m == b by { DivModAddDenominator(n - m, m); }
+    }
+  }
+
+  lemma DivModAddMultiple(a: nat, b: nat, c: nat)
+    requires a > 0
+    ensures (c * a + b) / a == c + b / a
+    ensures (c * a + b) % a == b % a
+  {
+    calc {
+      a * c + b;
+      ==
+      a * c + (a * (b / a) + b % a);
+      ==
+      a * (c + b / a) + b % a;
+    }
+    DivModIsUnique(a * c + b, a, c + b / a, b % a);
+  }
 
   lemma MultiplicationSubstitute(x: real, a: real, b: real)
     ensures a == b ==> (a * x == b * x)

--- a/src/Math/MeasureTheory.dfy
+++ b/src/Math/MeasureTheory.dfy
@@ -81,6 +81,16 @@ module MeasureTheory {
    Lemmas
   *******/
 
+  lemma PreImageIdentity<S(!new)>(f: S -> S, e: iset<S>)
+    requires forall s: S :: f(s) == s
+    ensures PreImage(f, e) == e
+  {}
+
+  lemma PreImagesEqual<S(!new),T,U>(f: S -> T, e: iset<T>, f': S -> U, e': iset<U>)
+    requires forall s: S :: f(s) in e <==> f'(s) in e'
+    ensures PreImage(f, e) == PreImage(f', e')
+  {}
+
   // Equation (2.18)
   lemma LemmaPosCountAddImpliesAdd<T(!new)>(event_space: iset<iset<T>>, sample_space: iset<T>, mu: iset<T> -> real)
     requires IsSigmaAlgebra(event_space, sample_space)


### PR DESCRIPTION
Used to take ~5min, now verifies in a few seconds

<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->

<!-- Is this a bug fix?  Remember to include a test in Test/git-issues/ -->

<!-- Is this a bug fix for an issue introduced in the latest release?  Mention this in the PR details and ensure a patch release is considered -->

<!-- Does this PR need tests?  Add them to `Test/` or to `Source/*.Test/…` and run them with `dotnet test` -->

<!-- Are you moving a large amount of code? Read CONTRIBUTING.md to learn how to do that while maintaining git history -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
