### PR TITLE
Independence proof for UniformPowerOfTwo

### DIFF
--- a/audit.log
+++ b/audit.log
@@ -41,7 +41,6 @@ Auditing ./src/Distributions/UniformPowerOfTwo/Correctness.dfy
  ProbUniformAlternative: Definition has `assume {:axiom}` statement in body. 
  UnifCorrectness2: Definition has `assume {:axiom}` statement in body. 
  UnifCorrectness2: Definition has `assume {:axiom}` statement in body. 
- ProbUnifIsIndepFn: Declaration has explicit `{:axiom}` attribute. 
 
 Auditing ./src/Distributions/UniformPowerOfTwo/Implementation.dfy
 
@@ -61,6 +60,8 @@ Auditing ./src/Math/Rationals.dfy
 
 Auditing ./src/ProbabilisticProgramming/Independence.dfy
  IsIndepFn: Declaration has explicit `{:axiom}` attribute. 
+ IsIndepFnImpliesMeasurable: Declaration has explicit `{:axiom}` attribute. 
+ IsIndepFnImpliesIsIndepFunction: Declaration has explicit `{:axiom}` attribute. 
  DeconstructIsIndepFn: Declaration has explicit `{:axiom}` attribute. 
  ReturnIsIndepFn: Declaration has explicit `{:axiom}` attribute. 
  IndepFnIsCompositional: Declaration has explicit `{:axiom}` attribute. 

--- a/src/Distributions/UniformPowerOfTwo/Correctness.dfy
+++ b/src/Distributions/UniformPowerOfTwo/Correctness.dfy
@@ -338,32 +338,27 @@ module UniformPowerOfTwoCorrectness {
     }
   }
 
-  lemma Congruence<T>(a: T -> bool, b: T, c: T)
-    requires b == c
-    requires a(b)
-    ensures a(c)
-  {}
-
   // Equation (4.7)
   lemma ProbUnifIsIndepFn(n: nat)
+    decreases n
     ensures Independence.IsIndepFn(UniformPowerOfTwoModel.ProbUnif(n))
   {
     var fn := UniformPowerOfTwoModel.ProbUnif(n);
     if n == 0 {
-      var evaluated := Monad.Return(0);
-      assert Independence.IsIndepFn(evaluated) by {
-        assert Independence.IsIndepFn(Monad.Return(0)) by {
-          Independence.ReturnIsIndepFn(0);
-        }
-        Congruence(Independence.IsIndepFn, Monad.Return(0), evaluated);
-      }
-      assert Monad.Return(0) == fn;
-      assert evaluated == fn;
-      assert Independence.IsIndepFn(fn) by {
-        Congruence(Independence.IsIndepFn, evaluated, fn);
-      }
+      Independence.ReturnIsIndepFn(0 as nat);
     } else {
-      assume false;
+      assert Independence.IsIndepFn(UniformPowerOfTwoModel.ProbUnif(n / 2)) by {
+        ProbUnifIsIndepFn(n / 2);
+      }
+      forall m: nat ensures Independence.IsIndepFn(UniformPowerOfTwoModel.UnifStep(m)) {
+        Independence.DeconstructIsIndepFn();
+        var g := UniformPowerOfTwoModel.UnifStepHelper(m);
+        forall b: bool ensures Independence.IsIndepFn(g(b)) {
+          Independence.ReturnIsIndepFn((if b then 2 * m + 1 else 2 * m) as nat);
+        }
+        Independence.IndepFnIsCompositional(Monad.Deconstruct, g);
+      }
+      Independence.IndepFnIsCompositional(UniformPowerOfTwoModel.ProbUnif(n / 2), UniformPowerOfTwoModel.UnifStep);
     }
   }
 
@@ -373,6 +368,7 @@ module UniformPowerOfTwoCorrectness {
     var f := ProbUnif1(n);
     assert MeasureTheory.IsMeasurable(RandomNumberGenerator.event_space, RandomNumberGenerator.event_space, f) by {
       ProbUnifIsIndepFn(n);
+      Independence.IsIndepFnImpliesMeasurable(UniformPowerOfTwoModel.ProbUnif(n));
       assert Independence.IsIndepFn(UniformPowerOfTwoModel.ProbUnif(n));
     }
     var g := ProbUnif1(n / 2);
@@ -613,6 +609,7 @@ module UniformPowerOfTwoCorrectness {
           assert Independence.IsIndepFn(UniformPowerOfTwoModel.ProbUnif(n / 2)) by {
             ProbUnifIsIndepFn(n / 2);
           }
+          Independence.IsIndepFnImpliesIsIndepFunction(UniformPowerOfTwoModel.ProbUnif(n / 2));
         }
         assert E in RandomNumberGenerator.event_space by { reveal EMeasure; }
         assert Independence.IsIndepFunctionCondition(UniformPowerOfTwoModel.ProbUnif(n / 2), A, E);
@@ -709,6 +706,7 @@ module UniformPowerOfTwoCorrectness {
           assert Independence.IsIndepFn(UniformPowerOfTwoModel.ProbUnif(n / 2)) by {
             ProbUnifIsIndepFn(n / 2);
           }
+          Independence.IsIndepFnImpliesIsIndepFunction(UniformPowerOfTwoModel.ProbUnif(n / 2));
         }
         assert E in RandomNumberGenerator.event_space;
         assert Independence.IsIndepFunctionCondition(UniformPowerOfTwoModel.ProbUnif(n / 2), A, E);

--- a/src/Distributions/UniformPowerOfTwo/Correctness.dfy
+++ b/src/Distributions/UniformPowerOfTwo/Correctness.dfy
@@ -338,9 +338,34 @@ module UniformPowerOfTwoCorrectness {
     }
   }
 
+  lemma Congruence<T>(a: T -> bool, b: T, c: T)
+    requires b == c
+    requires a(b)
+    ensures a(c)
+  {}
+
   // Equation (4.7)
-  lemma {:axiom} ProbUnifIsIndepFn(n: nat)
+  lemma ProbUnifIsIndepFn(n: nat)
     ensures Independence.IsIndepFn(UniformPowerOfTwoModel.ProbUnif(n))
+  {
+    var fn := UniformPowerOfTwoModel.ProbUnif(n);
+    if n == 0 {
+      var evaluated := Monad.Return(0);
+      assert Independence.IsIndepFn(evaluated) by {
+        assert Independence.IsIndepFn(Monad.Return(0)) by {
+          Independence.ReturnIsIndepFn(0);
+        }
+        Congruence(Independence.IsIndepFn, Monad.Return(0), evaluated);
+      }
+      assert Monad.Return(0) == fn;
+      assert evaluated == fn;
+      assert Independence.IsIndepFn(fn) by {
+        Congruence(Independence.IsIndepFn, evaluated, fn);
+      }
+    } else {
+      assume false;
+    }
+  }
 
   lemma ProbUnifIsMeasurePreserving(n: nat)
     ensures MeasureTheory.IsMeasurePreserving(RandomNumberGenerator.event_space, RandomNumberGenerator.mu, RandomNumberGenerator.event_space, RandomNumberGenerator.mu, ProbUnif1(n))

--- a/src/Distributions/UniformPowerOfTwo/Model.dfy
+++ b/src/Distributions/UniformPowerOfTwo/Model.dfy
@@ -16,8 +16,12 @@ module UniformPowerOfTwoModel {
   import Independence
   import WhileAndUntil
 
+  function UnifStepHelper(m: nat): bool -> Monad.Hurd<nat> {
+    (b: bool) => Monad.Return(if b then 2*m + 1 else 2*m)
+  }
+
   function UnifStep(m: nat): Monad.Hurd<nat> {
-    Monad.Bind(Monad.Deconstruct, (b: bool) => Monad.Return(if b then 2*m + 1 else 2*m))
+    Monad.Bind(Monad.Deconstruct, UnifStepHelper(m))
   }
 
   // Definition 48

--- a/src/ProbabilisticProgramming/Independence.dfy
+++ b/src/ProbabilisticProgramming/Independence.dfy
@@ -37,6 +37,12 @@ module Independence {
    Lemmas
   *******/
 
+  lemma IsIndepFnCongruence<A>(f: Monad.Hurd<A>, g: Monad.Hurd<A>)
+    requires IsIndepFn(f)
+    requires f == g
+    ensures IsIndepFn(g)
+  {}
+
   // Equation (3.17)
   lemma {:axiom} DeconstructIsIndepFn()
     ensures IsIndepFn(Monad.Deconstruct)

--- a/src/ProbabilisticProgramming/Independence.dfy
+++ b/src/ProbabilisticProgramming/Independence.dfy
@@ -29,19 +29,19 @@ module Independence {
   }
 
   // Definition 35
-  predicate {:axiom} IsIndepFn<A>(f: Monad.Hurd<A>)
-    ensures IsIndepFunction(f)
-    ensures MeasureTheory.IsMeasurable(RandomNumberGenerator.event_space, RandomNumberGenerator.event_space, s => f(s).1)
+  ghost predicate IsIndepFn<A(!new)>(f: Monad.Hurd<A>)
 
   /*******
    Lemmas
   *******/
 
-  lemma IsIndepFnCongruence<A>(f: Monad.Hurd<A>, g: Monad.Hurd<A>)
+  lemma {:axiom} IsIndepFnImpliesMeasurable<A(!new)>(f: Monad.Hurd<A>)
     requires IsIndepFn(f)
-    requires f == g
-    ensures IsIndepFn(g)
-  {}
+    ensures MeasureTheory.IsMeasurable(RandomNumberGenerator.event_space, RandomNumberGenerator.event_space, s => f(s).1)
+
+  lemma {:axiom} IsIndepFnImpliesIsIndepFunction<A(!new)>(f: Monad.Hurd<A>)
+    requires IsIndepFn(f)
+    ensures IsIndepFunction(f)
 
   // Equation (3.17)
   lemma {:axiom} DeconstructIsIndepFn()

--- a/src/ProbabilisticProgramming/Independence.dfy
+++ b/src/ProbabilisticProgramming/Independence.dfy
@@ -29,7 +29,7 @@ module Independence {
   }
 
   // Definition 35
-  ghost predicate IsIndepFn<A(!new)>(f: Monad.Hurd<A>)
+  ghost predicate {:axiom} IsIndepFn<A(!new)>(f: Monad.Hurd<A>)
 
   /*******
    Lemmas


### PR DESCRIPTION
I updated the definition of `IsIndepFn` in the process. The old definition seemed to be wrong.

<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->

<!-- Is this a bug fix?  Remember to include a test in Test/git-issues/ -->

<!-- Is this a bug fix for an issue introduced in the latest release?  Mention this in the PR details and ensure a patch release is considered -->

<!-- Does this PR need tests?  Add them to `Test/` or to `Source/*.Test/…` and run them with `dotnet test` -->

<!-- Are you moving a large amount of code? Read CONTRIBUTING.md to learn how to do that while maintaining git history -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
