### PR TITLE
Prove equivalence of implementation and model of UniformPowerOfTwo

### DIFF
--- a/audit.log
+++ b/audit.log
@@ -57,7 +57,6 @@ Auditing ./src/Distributions/UniformPowerOfTwo/Interface.dfy
 
 Auditing ./src/Distributions/UniformPowerOfTwo/Model.dfy
  SampleTerminates: Declaration has explicit `{:axiom}` attribute. 
- SampleCorrespondence: Definition has `assume {:axiom}` statement in body. 
 
 Auditing ./src/Distributions/UniformPowerOfTwo/UniformPowerOfTwo.dfy
 

--- a/audit.log
+++ b/audit.log
@@ -46,6 +46,7 @@ Auditing ./src/Distributions/Uniform/Implementation.dfy
 Auditing ./src/Distributions/Uniform/Interface.dfy
 
 Auditing ./src/Distributions/Uniform/Model.dfy
+ SampleTerminates: Declaration has explicit `{:axiom}` attribute. 
 
 Auditing ./src/Distributions/Uniform/Uniform.dfy
 
@@ -56,7 +57,6 @@ Auditing ./src/Distributions/UniformPowerOfTwo/Implementation.dfy
 Auditing ./src/Distributions/UniformPowerOfTwo/Interface.dfy
 
 Auditing ./src/Distributions/UniformPowerOfTwo/Model.dfy
- SampleTerminates: Declaration has explicit `{:axiom}` attribute. 
 
 Auditing ./src/Distributions/UniformPowerOfTwo/UniformPowerOfTwo.dfy
 

--- a/src/Distributions/Uniform/Correctness.dfy
+++ b/src/Distributions/Uniform/Correctness.dfy
@@ -57,7 +57,7 @@ module UniformCorrectness {
     var d := (x: nat) => x == i;
 
     assert Independence.IsIndepFn(b) && Quantifier.ExistsStar(WhileAndUntil.Helper2(b, c)) by {
-      UniformPowerOfTwo.Model.SampleTerminates(n);
+      Model.SampleTerminates(n);
     }
 
     assert WhileAndUntil.ProbUntilTerminates(b, c) by {

--- a/src/Distributions/Uniform/Model.dfy
+++ b/src/Distributions/Uniform/Model.dfy
@@ -22,9 +22,19 @@ module UniformModel {
   function Sample(n: nat): Monad.Hurd<nat>
     requires n > 0
   {
-    UniformPowerOfTwo.Model.SampleTerminates(n);
+    SampleTerminates(n);
     WhileAndUntil.ProbUntil(UniformPowerOfTwo.Model.Sample(n-1), (x: nat) => x < n)
   }
+
+
+  lemma {:axiom} SampleTerminates(n: nat)
+    requires n > 0
+    ensures
+      var b := UniformPowerOfTwo.Model.Sample(n - 1);
+      var c := (x: nat) => x < n;
+      && Independence.IsIndepFn(b)
+      && Quantifier.ExistsStar(WhileAndUntil.Helper2(b, c))
+      && WhileAndUntil.ProbUntilTerminates(b, c)
 
   function IntervalSample(a: int, b: int): (f: Monad.Hurd<int>)
     requires a < b

--- a/src/Distributions/UniformPowerOfTwo/Implementation.dfy
+++ b/src/Distributions/UniformPowerOfTwo/Implementation.dfy
@@ -15,17 +15,15 @@ module UniformPowerOfTwoImplementation {
       modifies this
       ensures Model.Sample(n)(old(s)) == (u, s)
     {
-      var k := 1;
       u := 0;
+      var n' := n;
 
-      while k <= n
-        decreases 2*n - k
-        invariant k >= 1
-        invariant Model.SampleAlternative(n)(old(s)) == Model.SampleAlternative(n, k, u)(s)
+      while n' > 0
+        invariant Model.SampleTailRecursive(n)(old(s)) == Model.SampleTailRecursive(n', u)(s)
       {
         var b := CoinSample();
-        k := 2*k;
         u := if b then 2*u + 1 else 2*u;
+        n' := n' / 2;
       }
       Model.SampleCorrespondence(n, old(s));
     }

--- a/src/Distributions/UniformPowerOfTwo/Model.dfy
+++ b/src/Distributions/UniformPowerOfTwo/Model.dfy
@@ -152,12 +152,12 @@ module UniformPowerOfTwoModel {
         (var (u, s') := Sample(Power2(k - l))(s); SampleTailRecursive(Power2(l - 1), u)(s'));
         { reveal Ineq1; }
         (var (u, s') := Sample(Power2(k - l))(s);
-          SampleTailRecursive(Power2(l - 1) / 2, if Monad.Head(s') then 2 * u + 1 else 2 * u)(Monad.Tail(s')));
+         SampleTailRecursive(Power2(l - 1) / 2, if Monad.Head(s') then 2 * u + 1 else 2 * u)(Monad.Tail(s')));
         { assert Power2(k - l + 1) / 2 == Power2(k - l); }
         (var (u', s') := Monad.Bind(Sample(Power2(k - l)), UnifStep)(s);
-          SampleTailRecursive(Power2(l - 2), u')(s'));
+         SampleTailRecursive(Power2(l - 2), u')(s'));
         (var (u', s') := Sample(Power2(k - l + 1))(s);
-          SampleTailRecursive(Power2(l - 2), u')(s'));
+         SampleTailRecursive(Power2(l - 2), u')(s'));
         Monad.Bind(Sample(Power2(k - l + 1)), (u: nat) => SampleTailRecursive(Power2(l - 2), u))(s);
         { RelateWithTailRecursive(k, l - 1, s); }
         Sample(Power2(k))(s);

--- a/src/Distributions/UniformPowerOfTwo/Model.dfy
+++ b/src/Distributions/UniformPowerOfTwo/Model.dfy
@@ -34,15 +34,6 @@ module UniformPowerOfTwoModel {
       Monad.Bind(Sample(n/2), UnifStep)
   }
 
-  lemma {:axiom} SampleTerminates(n: nat)
-    requires n > 0
-    ensures
-      var b := Sample(n - 1);
-      var c := (x: nat) => x < n;
-      && Independence.IsIndepFn(b)
-      && Quantifier.ExistsStar(WhileAndUntil.Helper2(b, c))
-      && WhileAndUntil.ProbUntilTerminates(b, c)
-
   // A tail recursive version of Sample, closer to the imperative implementation
   function SampleTailRecursive(n: nat, u: nat := 0): Monad.Hurd<nat>
     decreases n

--- a/src/Distributions/UniformPowerOfTwo/Model.dfy
+++ b/src/Distributions/UniformPowerOfTwo/Model.dfy
@@ -3,6 +3,7 @@
  *  SPDX-License-Identifier: MIT
  *******************************************************************************/
 
+include "../../Math/Helper.dfy"
 include "../../ProbabilisticProgramming/RandomNumberGenerator.dfy"
 include "../../ProbabilisticProgramming/Monad.dfy"
 include "../../ProbabilisticProgramming/Independence.dfy"
@@ -10,6 +11,7 @@ include "../../ProbabilisticProgramming/Quantifier.dfy"
 include "../../ProbabilisticProgramming/WhileAndUntil.dfy"
 
 module UniformPowerOfTwoModel {
+  import Helper
   import RandomNumberGenerator
   import Quantifier
   import Monad
@@ -41,42 +43,125 @@ module UniformPowerOfTwoModel {
       && Quantifier.ExistsStar(WhileAndUntil.Helper2(b, c))
       && WhileAndUntil.ProbUntilTerminates(b, c)
 
-  function SampleAlternative(n: nat, k: nat := 1, u: nat := 0): Monad.Hurd<nat>
-    requires k >= 1
-    decreases 2*n - k
+  // A tail recursive version of Sample, closer to the imperative implementation
+  function SampleTailRecursive(n: nat, u: nat := 0): Monad.Hurd<nat>
+    decreases n
   {
     (s: RandomNumberGenerator.RNG) =>
-      if k > n then
+      if n == 0 then
         (u, s)
       else
-        SampleAlternative(n, 2*k, if Monad.Head(s) then 2*u + 1 else 2*u)(Monad.Tail(s))
+        SampleTailRecursive(n / 2, if Monad.Head(s) then 2*u + 1 else 2*u)(Monad.Tail(s))
   }
 
-  // incomplete
+  // Equivalence of Sample and its tail-recursive version
   lemma SampleCorrespondence(n: nat, s: RandomNumberGenerator.RNG)
-    ensures SampleAlternative(n)(s) == Sample(n)(s)
+    ensures SampleTailRecursive(n)(s) == Sample(n)(s)
   {
-    var f := (m: nat) =>
-        var g := (b: bool) =>
-                   Monad.Return(if b then 2*m + 1 else 2*m);
-        Monad.Bind(Monad.Deconstruct, g);
     if n == 0 {
-    } else if n == 1 {
-      assert n / 2 == 0;
-      assert (0, s) == Sample(n/2)(s);
+      assert SampleTailRecursive(n)(s) == Sample(n)(s);
+    } else {
+      var k := Helper.Log2(n);
+      assert Power2(k - 1) <= n < Power2(k) by { Power2OfLog2(n); }
       calc {
+        SampleTailRecursive(n)(s);
+        { SampleTailRecursiveEqualIfSameLog2Floor(n, Power2(k - 1), k, 0, s); }
+        SampleTailRecursive(Power2(k - 1))(s);
+        Monad.Bind(Sample(Power2(-1)), (u: nat) => SampleTailRecursive(Power2(k - 1), u))(s);
+        { RelateWithTailRecursive(k - 1, k, s); }
+        Sample(Power2(k - 1))(s);
+        { SampleEqualIfSameLog2Floor(n, Power2(k - 1), k, s); }
         Sample(n)(s);
-        Monad.Bind(Sample(n/2), f)(s);
-        f(0)(s);
-        Monad.Bind(Monad.Deconstruct, (b: bool) => Monad.Return(if b then 1 else 0))(s);
-        Monad.Return(if Monad.Head(s) then 1 else 0)(Monad.Tail(s));
-        (if Monad.Head(s) then 1 else 0, Monad.Tail(s));
-        SampleAlternative(1, 2, if Monad.Head(s) then 1 else 0)(Monad.Tail(s));
-        SampleAlternative(1, 1, 0)(s);
-        SampleAlternative(n)(s);
+      }
+    }
+  }
+
+  // A version of Power(2, k) extended to negative k's.
+  function Power2(k: int): nat {
+    if k < 0 then 0 else if k == 0 then 1 else Power2(k - 1) * 2
+  }
+
+  lemma Power2Greater1(k: nat)
+    ensures Power2(k) >= 1
+  {}
+
+  lemma Power2OfLog2(n: nat)
+    ensures Power2(Helper.Log2(n) - 1) <= n < Power2(Helper.Log2(n))
+  {}
+
+  // All numbers between consecutive powers of 2 behave the same as arguments to SampleTailRecursive
+  lemma SampleTailRecursiveEqualIfSameLog2Floor(m: nat, n: nat, k: nat, u: nat, s: RandomNumberGenerator.RNG)
+    requires Power2(k - 1) <= m < Power2(k)
+    requires Power2(k - 1) <= n < Power2(k)
+    ensures SampleTailRecursive(m, u)(s) == SampleTailRecursive(n, u)(s)
+  {
+    if k == 0 {
+      assert m == n;
+    } else {
+      assert 1 <= m;
+      assert 1 <= n;
+      calc {
+        SampleTailRecursive(m, u)(s);
+        SampleTailRecursive(m / 2, if Monad.Head(s) then 2*u + 1 else 2*u)(Monad.Tail(s));
+        { SampleTailRecursiveEqualIfSameLog2Floor(m / 2, n / 2, k - 1, if Monad.Head(s) then 2*u + 1 else 2*u, Monad.Tail(s)); }
+        SampleTailRecursive(n / 2, if Monad.Head(s) then 2*u + 1 else 2*u)(Monad.Tail(s));
+        SampleTailRecursive(n, u)(s);
+      }
+    }
+  }
+
+  // All numbers between consecutive powers of 2 behave the same as arguments to Sample
+  lemma SampleEqualIfSameLog2Floor(m: nat, n: nat, k: nat, s: RandomNumberGenerator.RNG)
+    requires Power2(k - 1) <= m < Power2(k)
+    requires Power2(k - 1) <= n < Power2(k)
+    ensures Sample(m)(s) == Sample(n)(s)
+  {
+    if k == 0 {
+      assert m == n;
+    } else {
+      assert 1 <= m;
+      assert 1 <= n;
+      calc {
+        Sample(m)(s);
+        Monad.Bind(Sample(m / 2), UnifStep)(s);
+        { SampleEqualIfSameLog2Floor(m / 2, n / 2, k - 1, s); }
+        Monad.Bind(Sample(n / 2), UnifStep)(s);
+        Sample(n)(s);
+      }
+    }
+  }
+
+  // The induction invariant for the equivalence proof (generalized version of SampleCorrespondence)
+  lemma RelateWithTailRecursive(k: nat, l: nat, s: RandomNumberGenerator.RNG)
+    requires l <= k + 1
+    decreases l
+    ensures Monad.Bind(Sample(Power2(k - l)), (u: nat) => SampleTailRecursive(Power2(l - 1), u))(s) == Sample(Power2(k))(s)
+  {
+    if l == 0 {
+      calc {
+        Monad.Bind(Sample(Power2(k - l)), (u: nat) => SampleTailRecursive(Power2(l - 1), u))(s);
+        (var (u, s') := Sample(Power2(k - l))(s); SampleTailRecursive(0, u)(s'));
+        Sample(Power2(k))(s);
       }
     } else {
-      assume {:axiom} false;
+      var k' := k - l;
+      assert Ineq1: Power2(l - 1) >= 1 by { Power2Greater1(l - 1); }
+      assert Power2(k - l + 1) >= 1 by { Power2Greater1(k - l + 1); }
+      calc {
+        Monad.Bind(Sample(Power2(k - l)), (u: nat) => SampleTailRecursive(Power2(l - 1), u))(s);
+        (var (u, s') := Sample(Power2(k - l))(s); SampleTailRecursive(Power2(l - 1), u)(s'));
+        { reveal Ineq1; }
+        (var (u, s') := Sample(Power2(k - l))(s);
+          SampleTailRecursive(Power2(l - 1) / 2, if Monad.Head(s') then 2 * u + 1 else 2 * u)(Monad.Tail(s')));
+        { assert Power2(k - l + 1) / 2 == Power2(k - l); }
+        (var (u', s') := Monad.Bind(Sample(Power2(k - l)), UnifStep)(s);
+          SampleTailRecursive(Power2(l - 2), u')(s'));
+        (var (u', s') := Sample(Power2(k - l + 1))(s);
+          SampleTailRecursive(Power2(l - 2), u')(s'));
+        Monad.Bind(Sample(Power2(k - l + 1)), (u: nat) => SampleTailRecursive(Power2(l - 2), u))(s);
+        { RelateWithTailRecursive(k, l - 1, s); }
+        Sample(Power2(k))(s);
+      }
     }
   }
 }


### PR DESCRIPTION


<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->

<!-- Is this a bug fix?  Remember to include a test in Test/git-issues/ -->

<!-- Is this a bug fix for an issue introduced in the latest release?  Mention this in the PR details and ensure a patch release is considered -->

<!-- Does this PR need tests?  Add them to `Test/` or to `Source/*.Test/…` and run them with `dotnet test` -->

<!-- Are you moving a large amount of code? Read CONTRIBUTING.md to learn how to do that while maintaining git history -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
