### PR TITLE
Prove remaining {:axiom}s in Uniform

### DIFF
--- a/audit.log
+++ b/audit.log
@@ -5,9 +5,7 @@ src/Distributions/BernoulliExpNeg/Implementation.dfy(52,6): BernoulliExpNegSampl
 src/Distributions/BernoulliExpNeg/Model.dfy(30,4): GammaReductionLoop: Definition has `assume {:axiom}` statement in body. 
 src/Distributions/BernoulliExpNeg/Model.dfy(60,4): GammaLe1Loop: Definition has `assume {:axiom}` statement in body. 
 src/Distributions/Coin/Interface.dfy(20,6): CoinSample: Definition has `assume {:axiom}` statement in body. 
-src/Distributions/Uniform/Correctness.dfy(165,17): SampleIsIndepFn: Declaration has explicit `{:axiom}` attribute. 
 src/Distributions/Uniform/Implementation.dfy(43,6): UniformSample: Definition has `assume {:axiom}` statement in body. 
-src/Distributions/Uniform/Model.dfy(34,17): SampleTerminates: Declaration has explicit `{:axiom}` attribute. 
 src/Math/Exponential.dfy(11,17): EvalOne: Declaration has explicit `{:axiom}` attribute. 
 src/Math/Exponential.dfy(2,26): Exp: Declaration has explicit `{:axiom}` attribute. 
 src/Math/Exponential.dfy(4,17): FunctionalEquation: Declaration has explicit `{:axiom}` attribute. 
@@ -32,4 +30,5 @@ src/ProbabilisticProgramming/WhileAndUntil.dfy(165,17): EnsureProbWhileTerminate
 src/ProbabilisticProgramming/WhileAndUntil.dfy(171,17): ProbUntilProbabilityFraction: Declaration has explicit `{:axiom}` attribute. 
 src/ProbabilisticProgramming/WhileAndUntil.dfy(183,17): ProbUntilAsBind: Declaration has explicit `{:axiom}` attribute. 
 src/ProbabilisticProgramming/WhileAndUntil.dfy(197,4): EnsureProbUntilTerminatesAndForAll: Definition has `assume {:axiom}` statement in body. 
+src/ProbabilisticProgramming/WhileAndUntil.dfy(207,8): ProbWhileIsIndepFn: Definition has `assume {:axiom}` statement in body. 
 src/ProbabilisticProgramming/WhileAndUntil.dfy(39,4): ProbWhile: Definition has `assume {:axiom}` statement in body. 

--- a/src/Distributions/Uniform/Model.dfy
+++ b/src/Distributions/Uniform/Model.dfy
@@ -71,9 +71,9 @@ module Uniform.Model {
         }
         calc {
           RandomNumberGenerator.mu(e);
-          == { UniformPowerOfTwo.Correctness.UnifCorrectness2Inequality(2 * n, n); }
+        == { UniformPowerOfTwo.Correctness.UnifCorrectness2Inequality(2 * n, n); }
           n as real / (Helper.Power(2, Helper.Log2Floor(2 * n)) as real);
-          >
+        >
           0.0;
         }
       }

--- a/src/Distributions/Uniform/Model.dfy
+++ b/src/Distributions/Uniform/Model.dfy
@@ -4,6 +4,8 @@
  *******************************************************************************/
 
 module Uniform.Model {
+  import MeasureTheory
+  import Helper
   import RandomNumberGenerator
   import Quantifier
   import Monad
@@ -31,18 +33,53 @@ module Uniform.Model {
     (m: nat) => m < n
   }
 
-  lemma {:axiom} SampleTerminates(n: nat)
-    requires n > 0
-    ensures
-      && Independence.IsIndepFn(Proposal(n))
-      && Quantifier.ExistsStar(WhileAndUntil.ProposalIsAccepted(Proposal(n), Accept(n)))
-      && WhileAndUntil.ProbUntilTerminates(Proposal(n), Accept(n))
-
   function IntervalSample(a: int, b: int): (f: Monad.Hurd<int>)
     requires a < b
   {
     (s: RandomNumberGenerator.RNG) =>
       var (x, s') := Sample(b - a)(s);
       (a + x, s')
+  }
+
+  lemma SampleTerminates(n: nat)
+    requires n > 0
+    ensures
+      && Independence.IsIndepFn(Proposal(n))
+      && Quantifier.ExistsStar(WhileAndUntil.ProposalIsAccepted(Proposal(n), Accept(n)))
+      && WhileAndUntil.ProbUntilTerminates(Proposal(n), Accept(n))
+  {
+    assert Independence.IsIndepFn(Proposal(n)) by {
+      UniformPowerOfTwo.Correctness.SampleIsIndepFn(2 * n);
+    }
+    var e := iset s | WhileAndUntil.ProposalIsAccepted(Proposal(n), Accept(n))(s);
+    assert e in RandomNumberGenerator.event_space by {
+      assert e == MeasureTheory.PreImage(s => UniformPowerOfTwo.Model.Sample(2 * n)(s).0, (iset m: nat | m < n));
+      assert MeasureTheory.PreImage(s => UniformPowerOfTwo.Model.Sample(2 * n)(s).0, (iset m: nat | m < n)) in RandomNumberGenerator.event_space by {
+        assert Independence.IsIndepFn(UniformPowerOfTwo.Model.Sample(2 * n)) by {
+          UniformPowerOfTwo.Correctness.SampleIsIndepFn(2 * n);
+        }
+        assert MeasureTheory.IsMeasurable(RandomNumberGenerator.event_space, MeasureTheory.natEventSpace, s => UniformPowerOfTwo.Model.Sample(2 * n)(s).0) by {
+          Independence.IsIndepFnImpliesFstMeasurableNat(UniformPowerOfTwo.Model.Sample(2 * n));
+        }
+      }
+    }
+    assert Quantifier.ExistsStar(WhileAndUntil.ProposalIsAccepted(Proposal(n), Accept(n))) by {
+      assert RandomNumberGenerator.mu(e) > 0.0 by {
+        assert e == (iset s | UniformPowerOfTwo.Model.Sample(2 * n)(s).0 < n);
+        assert n <= Helper.Power(2, Helper.Log2Floor(2 * n)) by {
+          Helper.NLtPower2Log2FloorOf2N(n);
+        }
+        calc {
+          RandomNumberGenerator.mu(e);
+          == { UniformPowerOfTwo.Correctness.UnifCorrectness2Inequality(2 * n, n); }
+          n as real / (Helper.Power(2, Helper.Log2Floor(2 * n)) as real);
+          >
+          0.0;
+        }
+      }
+    }
+    assert WhileAndUntil.ProbUntilTerminates(Proposal(n), Accept(n)) by {
+      WhileAndUntil.EnsureProbUntilTerminates(Proposal(n), Accept(n));
+    }
   }
 }

--- a/src/Math/Helper.dfy
+++ b/src/Math/Helper.dfy
@@ -104,6 +104,19 @@ module Helper {
     ensures Power(2, Log2Floor(n)) <= n < Power(2, Log2Floor(n) + 1)
   {}
 
+  lemma NLtPower2Log2FloorOf2N(n: nat)
+    requires n >= 1
+    ensures n < Power(2, Log2Floor(2 * n))
+  {
+    calc {
+      n;
+    < { Power2OfLog2Floor(n); }
+      Power(2, Log2Floor(n) + 1);
+    == { Log2FloorDef(n); }
+      Power(2, Log2Floor(2 * n));
+    }
+  }
+
   lemma AdditionOfFractions(x: real, y: real, z: real)
     requires z != 0.0
     ensures (x / z) + (y / z) == (x + y) / z


### PR DESCRIPTION
There's technically one `{:axiom}` left: for the external Uniform implementation. But we won't be able to get rid of that.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
