### PR TITLE
Define loops like Hurd and prove some of their properties

### DIFF
--- a/audit.log
+++ b/audit.log
@@ -5,7 +5,7 @@ src/Distributions/BernoulliExpNeg/Implementation.dfy(52,6): BernoulliExpNegSampl
 src/Distributions/BernoulliExpNeg/Model.dfy(30,4): GammaReductionLoop: Definition has `assume {:axiom}` statement in body. 
 src/Distributions/BernoulliExpNeg/Model.dfy(60,4): GammaLe1Loop: Definition has `assume {:axiom}` statement in body. 
 src/Distributions/Coin/Interface.dfy(20,6): CoinSample: Definition has `assume {:axiom}` statement in body. 
-src/Distributions/Uniform/Implementation.dfy(43,6): UniformSample: Definition has `assume {:axiom}` statement in body. 
+src/Distributions/Uniform/Implementation.dfy(44,6): UniformSample: Definition has `assume {:axiom}` statement in body. 
 src/Math/Exponential.dfy(11,17): EvalOne: Declaration has explicit `{:axiom}` attribute. 
 src/Math/Exponential.dfy(2,26): Exp: Declaration has explicit `{:axiom}` attribute. 
 src/Math/Exponential.dfy(4,17): FunctionalEquation: Declaration has explicit `{:axiom}` attribute. 
@@ -20,12 +20,11 @@ src/ProbabilisticProgramming/Independence.dfy(46,17): IsIndepImpliesIsIndepFunct
 src/ProbabilisticProgramming/Independence.dfy(51,17): CoinIsIndep: Declaration has explicit `{:axiom}` attribute. 
 src/ProbabilisticProgramming/Independence.dfy(55,17): ReturnIsIndep: Declaration has explicit `{:axiom}` attribute. 
 src/ProbabilisticProgramming/Independence.dfy(59,17): IndepFnIsCompositional: Declaration has explicit `{:axiom}` attribute. 
-src/ProbabilisticProgramming/Loops.dfy(165,17): EnsureWhileTerminates: Declaration has explicit `{:axiom}` attribute. 
-src/ProbabilisticProgramming/Loops.dfy(171,17): UntilProbabilityFraction: Declaration has explicit `{:axiom}` attribute. 
-src/ProbabilisticProgramming/Loops.dfy(183,17): UntilAsBind: Declaration has explicit `{:axiom}` attribute. 
-src/ProbabilisticProgramming/Loops.dfy(197,4): EnsureUntilTerminatesAndForAll: Definition has `assume {:axiom}` statement in body. 
-src/ProbabilisticProgramming/Loops.dfy(207,8): WhileIsIndep: Definition has `assume {:axiom}` statement in body. 
-src/ProbabilisticProgramming/Loops.dfy(39,4): While: Definition has `assume {:axiom}` statement in body. 
+src/ProbabilisticProgramming/Loops.dfy(233,8): WhileUnroll: Definition has `assume {:axiom}` statement in body. 
+src/ProbabilisticProgramming/Loops.dfy(261,17): EnsureWhileTerminates: Declaration has explicit `{:axiom}` attribute. 
+src/ProbabilisticProgramming/Loops.dfy(267,17): UntilProbabilityFraction: Declaration has explicit `{:axiom}` attribute. 
+src/ProbabilisticProgramming/Loops.dfy(298,4): EnsureUntilTerminatesAndForAll: Definition has `assume {:axiom}` statement in body. 
+src/ProbabilisticProgramming/Loops.dfy(307,4): WhileIsIndep: Definition has `assume {:axiom}` statement in body. 
 src/ProbabilisticProgramming/Monad.dfy(134,17): CoinHasProbOneHalf: Declaration has explicit `{:axiom}` attribute. 
 src/ProbabilisticProgramming/Monad.dfy(141,17): MeasureHeadDrop: Declaration has explicit `{:axiom}` attribute. 
 src/ProbabilisticProgramming/Monad.dfy(147,17): TailIsMeasurePreserving: Declaration has explicit `{:axiom}` attribute. 

--- a/audit.log
+++ b/audit.log
@@ -1,32 +1,32 @@
-src/Distributions/BernoulliExpNeg/Correctness.dfy(13,17): Correctness: Declaration has explicit `{:axiom}` attribute.
-src/Distributions/BernoulliExpNeg/Correctness.dfy(17,17): SampleIsIndep: Declaration has explicit `{:axiom}` attribute.
-src/Distributions/BernoulliExpNeg/Implementation.dfy(34,6): BernoulliExpNegSample: Definition has `assume {:axiom}` statement in body.
-src/Distributions/BernoulliExpNeg/Implementation.dfy(52,6): BernoulliExpNegSampleCaseLe1: Definition has `assume {:axiom}` statement in body.
-src/Distributions/BernoulliExpNeg/Model.dfy(30,4): GammaReductionLoop: Definition has `assume {:axiom}` statement in body.
-src/Distributions/BernoulliExpNeg/Model.dfy(60,4): GammaLe1Loop: Definition has `assume {:axiom}` statement in body.
-src/Distributions/Coin/Interface.dfy(20,6): CoinSample: Definition has `assume {:axiom}` statement in body.
-src/Distributions/Uniform/Implementation.dfy(43,6): UniformSample: Definition has `assume {:axiom}` statement in body.
-src/Math/Analysis/Reals.dfy(35,17): LeastUpperBoundProperty: Declaration has explicit `{:axiom}` attribute.
-src/Math/Exponential.dfy(11,17): EvalOne: Declaration has explicit `{:axiom}` attribute.
-src/Math/Exponential.dfy(2,26): Exp: Declaration has explicit `{:axiom}` attribute.
-src/Math/Exponential.dfy(4,17): FunctionalEquation: Declaration has explicit `{:axiom}` attribute.
-src/Math/Exponential.dfy(7,17): Increasing: Declaration has explicit `{:axiom}` attribute.
-src/Math/Measures.dfy(150,17): CountableSumOfZeroesIsZero: Declaration has explicit `{:axiom}` attribute.
-src/Math/Measures.dfy(25,4): CountableSum: Definition has `assume {:axiom}` statement in body.
-src/ProbabilisticProgramming/Independence.dfy(28,27): IsIndep: Declaration has explicit `{:axiom}` attribute.
-src/ProbabilisticProgramming/Independence.dfy(34,17): IsIndepImpliesFstMeasurableBool: Declaration has explicit `{:axiom}` attribute.
-src/ProbabilisticProgramming/Independence.dfy(38,17): IsIndepImpliesFstMeasurableNat: Declaration has explicit `{:axiom}` attribute.
-src/ProbabilisticProgramming/Independence.dfy(42,17): IsIndepImpliesSndMeasurable: Declaration has explicit `{:axiom}` attribute.
-src/ProbabilisticProgramming/Independence.dfy(46,17): IsIndepImpliesIsIndepFunction: Declaration has explicit `{:axiom}` attribute.
-src/ProbabilisticProgramming/Independence.dfy(51,17): CoinIsIndep: Declaration has explicit `{:axiom}` attribute.
-src/ProbabilisticProgramming/Independence.dfy(55,17): ReturnIsIndep: Declaration has explicit `{:axiom}` attribute.
-src/ProbabilisticProgramming/Independence.dfy(59,17): IndepFnIsCompositional: Declaration has explicit `{:axiom}` attribute.
-src/ProbabilisticProgramming/Loops.dfy(233,8): WhileUnroll: Definition has `assume {:axiom}` statement in body.
-src/ProbabilisticProgramming/Loops.dfy(261,17): EnsureWhileTerminates: Declaration has explicit `{:axiom}` attribute.
-src/ProbabilisticProgramming/Loops.dfy(267,17): UntilProbabilityFraction: Declaration has explicit `{:axiom}` attribute.
-src/ProbabilisticProgramming/Loops.dfy(298,4): EnsureUntilTerminatesAndForAll: Definition has `assume {:axiom}` statement in body.
-src/ProbabilisticProgramming/Loops.dfy(307,4): WhileIsIndep: Definition has `assume {:axiom}` statement in body.
-src/ProbabilisticProgramming/Monad.dfy(134,17): CoinHasProbOneHalf: Declaration has explicit `{:axiom}` attribute.
-src/ProbabilisticProgramming/Monad.dfy(141,17): MeasureHeadDrop: Declaration has explicit `{:axiom}` attribute.
-src/ProbabilisticProgramming/Monad.dfy(147,17): TailIsMeasurePreserving: Declaration has explicit `{:axiom}` attribute.
-src/ProbabilisticProgramming/RandomSource.dfy(25,17): ProbIsProbabilityMeasure: Declaration has explicit `{:axiom}` attribute.
+src/Distributions/BernoulliExpNeg/Correctness.dfy(13,17): Correctness: Declaration has explicit `{:axiom}` attribute. 
+src/Distributions/BernoulliExpNeg/Correctness.dfy(17,17): SampleIsIndep: Declaration has explicit `{:axiom}` attribute. 
+src/Distributions/BernoulliExpNeg/Implementation.dfy(34,6): BernoulliExpNegSample: Definition has `assume {:axiom}` statement in body. 
+src/Distributions/BernoulliExpNeg/Implementation.dfy(52,6): BernoulliExpNegSampleCaseLe1: Definition has `assume {:axiom}` statement in body. 
+src/Distributions/BernoulliExpNeg/Model.dfy(30,4): GammaReductionLoop: Definition has `assume {:axiom}` statement in body. 
+src/Distributions/BernoulliExpNeg/Model.dfy(60,4): GammaLe1Loop: Definition has `assume {:axiom}` statement in body. 
+src/Distributions/Coin/Interface.dfy(20,6): CoinSample: Definition has `assume {:axiom}` statement in body. 
+src/Distributions/Uniform/Implementation.dfy(44,6): UniformSample: Definition has `assume {:axiom}` statement in body. 
+src/Math/Analysis/Reals.dfy(35,17): LeastUpperBoundProperty: Declaration has explicit `{:axiom}` attribute. 
+src/Math/Exponential.dfy(11,17): EvalOne: Declaration has explicit `{:axiom}` attribute. 
+src/Math/Exponential.dfy(2,26): Exp: Declaration has explicit `{:axiom}` attribute. 
+src/Math/Exponential.dfy(4,17): FunctionalEquation: Declaration has explicit `{:axiom}` attribute. 
+src/Math/Exponential.dfy(7,17): Increasing: Declaration has explicit `{:axiom}` attribute. 
+src/Math/Measures.dfy(150,17): CountableSumOfZeroesIsZero: Declaration has explicit `{:axiom}` attribute. 
+src/Math/Measures.dfy(25,4): CountableSum: Definition has `assume {:axiom}` statement in body. 
+src/ProbabilisticProgramming/Independence.dfy(28,27): IsIndep: Declaration has explicit `{:axiom}` attribute. 
+src/ProbabilisticProgramming/Independence.dfy(34,17): IsIndepImpliesFstMeasurableBool: Declaration has explicit `{:axiom}` attribute. 
+src/ProbabilisticProgramming/Independence.dfy(38,17): IsIndepImpliesFstMeasurableNat: Declaration has explicit `{:axiom}` attribute. 
+src/ProbabilisticProgramming/Independence.dfy(42,17): IsIndepImpliesSndMeasurable: Declaration has explicit `{:axiom}` attribute. 
+src/ProbabilisticProgramming/Independence.dfy(46,17): IsIndepImpliesIsIndepFunction: Declaration has explicit `{:axiom}` attribute. 
+src/ProbabilisticProgramming/Independence.dfy(51,17): CoinIsIndep: Declaration has explicit `{:axiom}` attribute. 
+src/ProbabilisticProgramming/Independence.dfy(55,17): ReturnIsIndep: Declaration has explicit `{:axiom}` attribute. 
+src/ProbabilisticProgramming/Independence.dfy(59,17): BindIsIndep: Declaration has explicit `{:axiom}` attribute. 
+src/ProbabilisticProgramming/Loops.dfy(229,8): WhileUnroll: Definition has `assume {:axiom}` statement in body. 
+src/ProbabilisticProgramming/Loops.dfy(257,17): EnsureWhileTerminates: Declaration has explicit `{:axiom}` attribute. 
+src/ProbabilisticProgramming/Loops.dfy(263,17): UntilProbabilityFraction: Declaration has explicit `{:axiom}` attribute. 
+src/ProbabilisticProgramming/Loops.dfy(294,4): EnsureUntilTerminatesAndForAll: Definition has `assume {:axiom}` statement in body. 
+src/ProbabilisticProgramming/Loops.dfy(317,4): WhileIsIndep: Definition has `assume {:axiom}` statement in body. 
+src/ProbabilisticProgramming/Monad.dfy(134,17): CoinHasProbOneHalf: Declaration has explicit `{:axiom}` attribute. 
+src/ProbabilisticProgramming/Monad.dfy(141,17): MeasureHeadDrop: Declaration has explicit `{:axiom}` attribute. 
+src/ProbabilisticProgramming/Monad.dfy(147,17): TailIsMeasurePreserving: Declaration has explicit `{:axiom}` attribute. 
+src/ProbabilisticProgramming/RandomSource.dfy(25,17): ProbIsProbabilityMeasure: Declaration has explicit `{:axiom}` attribute. 

--- a/src/Distributions/Bernoulli/Correctness.dfy
+++ b/src/Distributions/Bernoulli/Correctness.dfy
@@ -34,7 +34,7 @@ module Bernoulli.Correctness {
       }
     }
 
-    Independence.IndepFnIsCompositional(f, g);
+    Independence.BindIsIndep(f, g);
   }
 
 

--- a/src/Distributions/Bernoulli/Correctness.dfy
+++ b/src/Distributions/Bernoulli/Correctness.dfy
@@ -76,12 +76,14 @@ module Bernoulli.Correctness {
         }
       }
 
-      calc {
-        e;
-        iset s | Uniform.Model.Sample(n)(s).0 < m;
-        iset s | Uniform.Model.Sample(n)(s).0 == m-1 || Uniform.Model.Sample(n)(s).0 < m-1;
-        (iset s | Uniform.Model.Sample(n)(s).0 == m-1) + (iset s | Uniform.Model.Sample(n)(s).0 < m-1);
-        e1 + e2;
+      assert e == e1 + e2 by {
+        calc {
+          e;
+          iset s | Uniform.Model.Sample(n)(s).0 < m;
+          iset s | Uniform.Model.Sample(n)(s).0 == m-1 || Uniform.Model.Sample(n)(s).0 < m-1;
+          (iset s | Uniform.Model.Sample(n)(s).0 == m-1) + (iset s | Uniform.Model.Sample(n)(s).0 < m-1);
+          e1 + e2;
+        }
       }
 
       assert A1: e1 in Rand.eventSpace && Rand.prob(e1) == 1.0 / (n as real) by {
@@ -93,26 +95,14 @@ module Bernoulli.Correctness {
         BernoulliCorrectness(m-1, n);
       }
 
-      assert A3: (1.0 / n as real) + ((m-1) as real / n as real) == (1.0 + (m-1) as real) / n as real by {
-        var x := 1.0;
-        var y := (m-1) as real;
-        var z := n as real;
-        Helper.AdditionOfFractions(x, y, z);
-        assert (x / z) + (y / z) == (x + y) / z;
-      }
-
       calc {
         Rand.prob(e);
-        { assert e == e1 + e2; }
         Rand.prob(e1 + e2);
         { reveal A1; reveal A2; assert e1 * e2 == iset{}; Rand.ProbIsProbabilityMeasure(); Measures.PosCountAddImpliesAdd(Rand.eventSpace, Rand.sampleSpace, Rand.prob); assert Measures.IsAdditive(Rand.eventSpace, Rand.prob); }
         Rand.prob(e1) + Rand.prob(e2);
         { reveal A1; reveal A2; }
-        (1.0 / n as real) + ((m-1) as real / n as real);
-        { reveal A3; }
-        (1.0 + (m-1) as real) / n as real;
-        (1.0 + (m as real) - (1 as real)) / n as real;
-        (1.0 + (m as real) - 1.0) / n as real;
+        (1.0 / n as real) + ((m - 1) as real / n as real);
+        { AdditionOfFractions(m, n); }
         m as real / n as real;
       }
 
@@ -124,4 +114,9 @@ module Bernoulli.Correctness {
       }
     }
   }
+
+  lemma AdditionOfFractions(m: nat, n: nat)
+    requires n > 0
+    ensures (1.0 / n as real) + ((m - 1) as real / n as real) == (m as real) / n as real
+  {}
 }

--- a/src/Distributions/Bernoulli/Model.dfy
+++ b/src/Distributions/Bernoulli/Model.dfy
@@ -8,7 +8,7 @@ module Bernoulli.Model {
   import Monad
 
   // Footnote 5, p. 82
-  function Sample(numer: nat, denom: nat): (f: Monad.Hurd<bool>)
+  ghost function Sample(numer: nat, denom: nat): (f: Monad.Hurd<bool>)
     requires denom != 0
     requires numer <= denom
     ensures forall s :: f(s).0 == (Uniform.Model.Sample(denom)(s).0 < numer)

--- a/src/Distributions/BernoulliExpNeg/Model.dfy
+++ b/src/Distributions/BernoulliExpNeg/Model.dfy
@@ -10,7 +10,7 @@ module BernoulliExpNeg.Model {
   import Loops
   import BernoulliModel = Bernoulli.Model
 
-  function Sample(gamma: Rationals.Rational): Monad.Hurd<bool>
+  ghost function Sample(gamma: Rationals.Rational): Monad.Hurd<bool>
     requires gamma.denom != 0
     requires gamma.numer >= 0
   {
@@ -24,7 +24,7 @@ module BernoulliExpNeg.Model {
     )
   }
 
-  function GammaReductionLoop(gamma: Rationals.Rational): Monad.Hurd<(bool, Rationals.Rational)>
+  ghost function GammaReductionLoop(gamma: Rationals.Rational): Monad.Hurd<(bool, Rationals.Rational)>
     requires gamma.numer >= 0
   {
     assume {:axiom} false; // assume termination
@@ -35,7 +35,7 @@ module BernoulliExpNeg.Model {
     )
   }
 
-  function GammaReductionLoopIter(bgamma: (bool, Rationals.Rational)): Monad.Hurd<(bool, Rationals.Rational)>
+  ghost function GammaReductionLoopIter(bgamma: (bool, Rationals.Rational)): Monad.Hurd<(bool, Rationals.Rational)>
     requires bgamma.1.numer >= 0
   {
     Monad.Bind(
@@ -44,7 +44,7 @@ module BernoulliExpNeg.Model {
     )
   }
 
-  function SampleGammaLe1(gamma: Rationals.Rational): Monad.Hurd<bool>
+  ghost function SampleGammaLe1(gamma: Rationals.Rational): Monad.Hurd<bool>
   {
     if 0 <= gamma.numer <= gamma.denom
     then Monad.Bind(
@@ -54,7 +54,7 @@ module BernoulliExpNeg.Model {
     else Monad.Return(false) // to keep this function total, we return a dummy value here
   }
 
-  function GammaLe1Loop(gamma: Rationals.Rational, ak: (bool, nat)): Monad.Hurd<(bool, nat)>
+  ghost function GammaLe1Loop(gamma: Rationals.Rational, ak: (bool, nat)): Monad.Hurd<(bool, nat)>
     requires 0 <= gamma.numer <= gamma.denom
   {
     assume {:axiom} false; // assume termination
@@ -65,7 +65,7 @@ module BernoulliExpNeg.Model {
     )
   }
 
-  function GammaLe1LoopIter(gamma: Rationals.Rational, ak: (bool, nat)): Monad.Hurd<(bool, nat)>
+  ghost function GammaLe1LoopIter(gamma: Rationals.Rational, ak: (bool, nat)): Monad.Hurd<(bool, nat)>
     requires 0 <= gamma.numer <= gamma.denom
   {
     Monad.Bind(

--- a/src/Distributions/Uniform/Correctness.dfy
+++ b/src/Distributions/Uniform/Correctness.dfy
@@ -162,7 +162,7 @@ module Uniform.Correctness {
     assert Independence.IsIndep(Model.Proposal(n)) by {
       UniformPowerOfTwo.Correctness.SampleIsIndep(2 * n);
     }
-    assert Loops.UntilTerminates(Model.Proposal(n), Model.Accept(n)) by {
+    assert Loops.UntilTerminatesAlmostSurely(Model.Proposal(n), Model.Accept(n)) by {
       Model.SampleTerminates(n);
     }
     Loops.UntilIsIndep(Model.Proposal(n), Model.Accept(n));

--- a/src/Distributions/Uniform/Implementation.dfy
+++ b/src/Distributions/Uniform/Implementation.dfy
@@ -23,6 +23,7 @@ module Uniform.Implementation {
         invariant Model.Sample(n)(old(s)) == Model.Sample(n)(prevS)
         invariant (u, s) == Model.Proposal(n)(prevS)
       {
+        Model.SampleUnroll(n, prevS);
         prevS := s;
         u := UniformPowerOfTwoSample(2 * n);
       }

--- a/src/Distributions/UniformPowerOfTwo/Correctness.dfy
+++ b/src/Distributions/UniformPowerOfTwo/Correctness.dfy
@@ -174,9 +174,9 @@ module UniformPowerOfTwo.Correctness {
         forall b: bool ensures Independence.IsIndep(g(b)) {
           Independence.ReturnIsIndep((if b then 2 * m + 1 else 2 * m) as nat);
         }
-        Independence.IndepFnIsCompositional(Monad.Coin, g);
+        Independence.BindIsIndep(Monad.Coin, g);
       }
-      Independence.IndepFnIsCompositional(Model.Sample(n / 2), Model.UnifStep);
+      Independence.BindIsIndep(Model.Sample(n / 2), Model.UnifStep);
     }
   }
 

--- a/src/ProbabilisticProgramming/Independence.dfy
+++ b/src/ProbabilisticProgramming/Independence.dfy
@@ -56,7 +56,7 @@ module Independence {
     ensures IsIndep(Monad.Return(x))
 
   // Equation (3.19)
-  lemma {:axiom} IndepFnIsCompositional<A, B>(f: Monad.Hurd<A>, g: A -> Monad.Hurd<B>)
+  lemma {:axiom} BindIsIndep<A, B>(f: Monad.Hurd<A>, g: A -> Monad.Hurd<B>)
     requires IsIndep(f)
     requires forall a :: IsIndep(g(a))
     ensures IsIndep(Monad.Bind(f, g))

--- a/src/ProbabilisticProgramming/Loops.dfy
+++ b/src/ProbabilisticProgramming/Loops.dfy
@@ -14,73 +14,76 @@ module Loops {
   ************/
 
   // Definition 37
-  function WhileCut<A>(condition: A -> bool, body: A -> Monad.Hurd<A>, n: nat, init: A): Monad.Hurd<A> {
-    if n == 0 then
+  function WhileCut<A>(condition: A -> bool, body: A -> Monad.Hurd<A>, init: A, fuel: nat): Monad.Hurd<A> {
+    if fuel == 0 then
       Monad.Return(init)
     else (
            if condition(init) then
-             Monad.Bind(body(init), (a: A) => WhileCut(condition, body, n-1, a))
+             Monad.Bind(body(init), (a: A) => WhileCut(condition, body, a, fuel - 1))
            else
              Monad.Return(init)
          )
   }
 
+  ghost predicate WhileCutTerminates<A>(condition: A -> bool, body: A -> Monad.Hurd<A>, init: A, s: Rand.Bitstream) {
+    exists fuel: nat :: WhileCutTerminatesWithFuel(condition, body, init, s)(fuel)
+  }
+
+  ghost function WhileCutTerminatesWithFuel<A>(condition: A -> bool, body: A -> Monad.Hurd<A>, init: A, s: Rand.Bitstream): nat -> bool {
+    (fuel: nat) => !condition(WhileCut(condition, body, init, fuel)(s).0)
+  }
+
   // Definition 39 / True iff Prob(iset s | While(condition, body, a)(s) terminates) == 1
-  ghost predicate WhileTerminates<A(!new)>(condition: A -> bool, body: A -> Monad.Hurd<A>) {
+  ghost predicate WhileTerminatesAlmostSurely<A(!new)>(condition: A -> bool, body: A -> Monad.Hurd<A>) {
     var p := (a: A) =>
-               (s: Rand.Bitstream) => exists n :: !condition(WhileCut(condition, body, n, a)(s).0);
+               (s: Rand.Bitstream) => exists n :: !condition(WhileCut(condition, body, a, n)(s).0);
     forall a :: Quantifier.AlmostSurely(p(a))
   }
 
-  // Theorem 38
-  function While<A>(condition: A -> bool, body: A -> Monad.Hurd<A>, init: A): (f: Monad.Hurd<A>)
-    requires WhileTerminates(condition, body)
+  // Equation (3.25)
+  ghost function While<A>(condition: A -> bool, body: A -> Monad.Hurd<A>, init: A): (f: Monad.Hurd<A>)
   {
-    assume {:axiom} false; // assume termination
-    if condition(init) then
-      Monad.Bind(body(init), (a': A) => While(condition, body, a'))
-    else
-      Monad.Return(init)
+    (s: Rand.Bitstream) =>
+      if WhileCutTerminates(condition, body, init, s)
+      then
+        var fuel := MinimalFuel(condition, body, init, s);
+        WhileCut(condition, body, init, fuel)(s)
+      else
+        // In HOL, Hurd returns `arb` here, which is not possible in Dafny.
+        (init, s)
   }
 
-  method WhileImperative<A>(condition: A -> bool, body: A -> Monad.Hurd<A>, init: A, s: Rand.Bitstream) returns (t: (A, Rand.Bitstream))
-    requires WhileTerminates(condition, body)
-    ensures While(condition, body, init)(s) == t
-    decreases *
+  ghost function MinimalFuel<A>(condition: A -> bool, body: A -> Monad.Hurd<A>, init: A, s: Rand.Bitstream): (fuel: nat)
+    requires WhileCutTerminates(condition, body, init, s)
+    ensures WhileCutTerminatesWithFuel(condition, body, init, s)(fuel)
+    ensures forall fuel': nat :: WhileCutTerminatesWithFuel(condition, body, init, s)(fuel') ==> fuel <= fuel'
   {
-    while condition(init)
-      decreases *
-    {
-      var (a, s) := body(init)(s);
-    }
-    return (init, s);
+    var fuelBound :| WhileCutTerminatesWithFuel(condition, body, init, s)(fuelBound);
+    Minimal(WhileCutTerminatesWithFuel(condition, body, init, s), fuelBound)
   }
 
-  method WhileImperativeAlternative<A>(condition: A -> bool, body: A -> Monad.Hurd<A>, init: A, s: Rand.Bitstream) returns (t: (A, Rand.Bitstream))
-    requires WhileTerminates(condition, body)
-    ensures While(condition, body, init)(s) == t
-    decreases *
+  ghost function Minimal(property: nat -> bool, bound: nat, i: nat := 0): (n: nat)
+    decreases bound - i
+    requires i <= bound
+    requires property(bound)
+    ensures property(n)
+    ensures i <= n <= bound
+    ensures forall m: nat | i <= m :: property(m) ==> n <= m
   {
-    while true
-      decreases *
-    {
-      if !condition(init) {
-        return (init, s);
-      } else {
-        var (a, s) := body(init)(s);
-      }
-    }
+    if i == bound || property(i)
+    then i
+    else Minimal(property, bound, i + 1)
   }
 
-  ghost predicate UntilTerminates<A(!new)>(proposal: Monad.Hurd<A>, accept: A -> bool) {
+  ghost predicate UntilTerminatesAlmostSurely<A(!new)>(proposal: Monad.Hurd<A>, accept: A -> bool) {
     var reject := (a: A) => !accept(a);
     var body := (a: A) => proposal;
-    WhileTerminates(reject, body)
+    WhileTerminatesAlmostSurely(reject, body)
   }
 
   // Definition 44
-  function Until<A>(proposal: Monad.Hurd<A>, accept: A -> bool): (f: Monad.Hurd<A>)
-    requires UntilTerminates(proposal, accept)
+  ghost function Until<A>(proposal: Monad.Hurd<A>, accept: A -> bool): (f: Monad.Hurd<A>)
+    requires UntilTerminatesAlmostSurely(proposal, accept)
     ensures
       var reject := (a: A) => !accept(a);
       var body := (a: A) => proposal;
@@ -89,16 +92,6 @@ module Loops {
     var reject := (a: A) => !accept(a);
     var body := (a: A) => proposal;
     Monad.Bind(proposal, (a: A) => While(reject, body, a))
-  }
-
-  method UntilImperative<A>(proposal: Monad.Hurd<A>, accept: A -> bool, s: Rand.Bitstream) returns (t: (A, Rand.Bitstream))
-    requires UntilTerminates(proposal, accept)
-    ensures t == Until(proposal, accept)(s)
-    decreases *
-  {
-    var reject := (a: A) => !accept(a);
-    var body := (a: A) => proposal;
-    t := WhileImperative(reject, body, proposal(s).0, proposal(s).1);
   }
 
   function WhileLoopExitsAfterOneIteration<A(!new)>(body: A -> Monad.Hurd<A>, condition: A -> bool, init: A): (Rand.Bitstream -> bool) {
@@ -111,15 +104,15 @@ module Loops {
       accept(proposal(s).0)
   }
 
-  function UntilLoopResultIsAccepted<A>(proposal: Monad.Hurd<A>, accept: A -> bool): (Rand.Bitstream -> bool)
-    requires UntilTerminates(proposal, accept)
+  ghost function UntilLoopResultIsAccepted<A>(proposal: Monad.Hurd<A>, accept: A -> bool): (Rand.Bitstream -> bool)
+    requires UntilTerminatesAlmostSurely(proposal, accept)
   {
     (s: Rand.Bitstream) =>
       accept(Until(proposal, accept)(s).0)
   }
 
   ghost function UntilLoopResultHasProperty<A>(proposal: Monad.Hurd<A>, accept: A -> bool, property: A -> bool): iset<Rand.Bitstream>
-    requires UntilTerminates(proposal, accept)
+    requires UntilTerminatesAlmostSurely(proposal, accept)
   {
     iset s | property(Until(proposal, accept)(s).0)
   }
@@ -139,15 +132,118 @@ module Loops {
    Lemmas
   *******/
 
+  lemma MinimalFuelUnroll<A>(condition: A -> bool, body: A -> Monad.Hurd<A>, init: A, s: Rand.Bitstream, init': A, s': Rand.Bitstream, fuel': nat)
+    requires WhileCutTerminates(condition, body, init', s')
+    requires MinimalFuel(condition, body, init', s') == fuel'
+    requires condition(init)
+    requires body(init)(s) == (init', s')
+    ensures WhileCutTerminates(condition, body, init, s)
+    ensures MinimalFuel(condition, body, init, s) == fuel' + 1
+  {
+    assert WhileCutTerminates(condition, body, init, s) by {
+      WhileCutTerminatesWithFuelUnroll(condition, body, init, s, init', s', fuel');
+    }
+    var fuel := MinimalFuel(condition, body, init, s);
+    assert fuel == fuel' + 1 by {
+      WhileCutTerminatesWithFuelUnroll(condition, body, init, s, init', s', fuel');
+      WhileCutTerminatesWithFuelUnroll(condition, body, init, s, init', s', fuel - 1);
+    }
+  }
+
+  lemma WhileCutUnroll<A>(condition: A -> bool, body: A -> Monad.Hurd<A>, init: A, s: Rand.Bitstream, init': A, s': Rand.Bitstream, fuel: nat)
+    requires condition(init)
+    requires body(init)(s) == (init', s')
+    ensures WhileCut(condition, body, init, fuel + 1)(s) == WhileCut(condition, body, init', fuel)(s')
+  {}
+
+
+  lemma WhileCutTerminatesWithFuelUnroll<A>(condition: A -> bool, body: A -> Monad.Hurd<A>, init: A, s: Rand.Bitstream, init': A, s': Rand.Bitstream, fuel: nat)
+    requires condition(init)
+    requires body(init)(s) == (init', s')
+    ensures WhileCutTerminatesWithFuel(condition, body, init, s)(fuel + 1) == WhileCutTerminatesWithFuel(condition, body, init', s')(fuel)
+  {}
+
+  lemma WhileUnrollIfConditionSatisfied<A>(condition: A -> bool, body: A -> Monad.Hurd<A>, init: A, s: Rand.Bitstream, init': A, s': Rand.Bitstream, loop: (A, Rand.Bitstream), unrolled: (A, Rand.Bitstream))
+    requires WhileCutTerminates(condition, body, init, s)
+    requires condition(init)
+    requires body(init)(s) == (init', s')
+    requires loop == While(condition, body, init)(s)
+    requires unrolled == While(condition, body, init')(s')
+    ensures loop == unrolled
+  {
+    var fuel: nat := MinimalFuel(condition, body, init, s);
+    assert fuel >= 1;
+    var fuel': nat := fuel - 1;
+    assert WhileCutTerminatesWithFuel(condition, body, init', s')(fuel');
+    assert WhileCutTerminates(condition, body, init', s');
+    var minFuel: nat := MinimalFuel(condition, body, init', s');
+    assert minFuel == fuel' by {
+      MinimalFuelUnroll(condition, body, init, s, init', s', minFuel);
+    }
+    assert loop == unrolled by {
+      calc {
+        loop;
+        WhileCut(condition, body, init, fuel)(s);
+        { WhileCutUnroll(condition, body, init, s, init', s', fuel'); }
+        WhileCut(condition, body, init', fuel')(s');
+        unrolled;
+      }
+    }
+  }
+
+  lemma WhileUnrollIfTerminates<A>(condition: A -> bool, body: A -> Monad.Hurd<A>, init: A, s: Rand.Bitstream, fuel: nat, loop: (A, Rand.Bitstream), unrolled: (A, Rand.Bitstream))
+    requires WhileCutTerminates(condition, body, init, s)
+    requires fuel == MinimalFuel(condition, body, init, s)
+    requires loop == While(condition, body, init)(s)
+    requires unrolled == (if condition(init) then Monad.Bind(body(init), (init': A) => While(condition, body, init')) else Monad.Return(init))(s)
+    ensures loop == unrolled
+  {
+    if condition(init) {
+      var (init', s') := body(init)(s);
+      calc {
+        loop;
+        { WhileUnrollIfConditionSatisfied(condition, body, init, s, init', s', loop, unrolled); }
+        While(condition, body, init')(s');
+        unrolled;
+      }
+    } else {
+      calc {
+        loop;
+        (init, s);
+        unrolled;
+      }
+    }
+  }
+
+  // Theorem 38
+  lemma WhileUnroll<A>(condition: A -> bool, body: A -> Monad.Hurd<A>, init: A, s: Rand.Bitstream)
+    requires WhileTerminatesAlmostSurely(condition, body)
+    ensures While(condition, body, init)(s) == (if condition(init) then Monad.Bind(body(init), (init': A) => While(condition, body, init')) else Monad.Return(init))(s)
+  {
+    var loop := While(condition, body, init)(s);
+    var unrolled := (if condition(init) then Monad.Bind(body(init), (init': A) => While(condition, body, init')) else Monad.Return(init))(s);
+    assert loop == unrolled by {
+      if WhileCutTerminates(condition, body, init, s) {
+        var fuel: nat := MinimalFuel(condition, body, init, s);
+        WhileUnrollIfTerminates(condition, body, init, s, fuel, loop, unrolled);
+      } else {
+        // In this case, equality does not hold in Dafny.
+        // Hurd avoids this problem in HOL by having `While` return `arb` (an arbitrary value) in this case.
+        // That's not possible in Dafny, so we must resort to `assume false`.
+        assume {:axiom} false;
+      }
+    }
+  }
+
   lemma EnsureUntilTerminates<A(!new)>(proposal: Monad.Hurd<A>, accept: A -> bool)
     requires Independence.IsIndep(proposal)
     requires Quantifier.WithPosProb((s: Rand.Bitstream) => accept(proposal(s).0))
-    ensures UntilTerminates(proposal, accept)
+    ensures UntilTerminatesAlmostSurely(proposal, accept)
   {
     var reject := (a: A) => !accept(a);
     var body := (a: A) => proposal;
     var proposalIsAccepted := (s: Rand.Bitstream) => accept(proposal(s).0);
-    assert UntilTerminates(proposal, accept) by {
+    assert UntilTerminatesAlmostSurely(proposal, accept) by {
       forall a: A ensures Independence.IsIndep(body(a)) {
         assert body(a) == proposal;
       }
@@ -155,7 +251,7 @@ module Loops {
         assert Quantifier.WithPosProb(proposalIsAccepted);
         assert (iset s | proposalIsAccepted(s)) == (iset s | WhileLoopExitsAfterOneIteration(body, reject, a)(s));
       }
-      assert WhileTerminates(reject, body) by {
+      assert WhileTerminatesAlmostSurely(reject, body) by {
         EnsureWhileTerminates(reject, body);
       }
     }
@@ -165,13 +261,13 @@ module Loops {
   lemma {:axiom} EnsureWhileTerminates<A(!new)>(condition: A -> bool, body: A -> Monad.Hurd<A>)
     requires forall a :: Independence.IsIndep(body(a))
     requires forall a :: Quantifier.WithPosProb(WhileLoopExitsAfterOneIteration(body, condition, a))
-    ensures WhileTerminates(condition, body)
+    ensures WhileTerminatesAlmostSurely(condition, body)
 
   // Theorem 45 (wrong!) / PROB_BERN_UNTIL (correct!)
   lemma {:axiom} UntilProbabilityFraction<A>(proposal: Monad.Hurd<A>, accept: A -> bool, d: A -> bool)
     requires Independence.IsIndep(proposal)
     requires Quantifier.WithPosProb(ProposalIsAccepted(proposal, accept))
-    ensures UntilTerminates(proposal, accept)
+    ensures UntilTerminatesAlmostSurely(proposal, accept)
     ensures
       && UntilLoopResultHasProperty(proposal, accept, d) in Rand.eventSpace
       && ProposalIsAcceptedAndHasProperty(proposal, accept, d) in Rand.eventSpace
@@ -180,17 +276,22 @@ module Loops {
       && Rand.prob(UntilLoopResultHasProperty(proposal, accept, d)) == Rand.prob(ProposalIsAcceptedAndHasProperty(proposal, accept, d)) / Rand.prob(ProposalAcceptedEvent(proposal, accept))
 
   // Equation (3.39)
-  lemma {:axiom} UntilAsBind<A(!new)>(proposal: Monad.Hurd<A>, accept: A -> bool, s: Rand.Bitstream)
+  lemma UntilUnroll<A(!new)>(proposal: Monad.Hurd<A>, accept: A -> bool, s: Rand.Bitstream)
     requires Independence.IsIndep(proposal)
-    requires Quantifier.WithPosProb(ProposalIsAccepted(proposal, accept))
-    ensures UntilTerminates(proposal, accept)
-    ensures Until(proposal, accept) == Monad.Bind(proposal, (x: A) => if accept(x) then Monad.Return(x) else Until(proposal, accept))
+    requires UntilTerminatesAlmostSurely(proposal, accept)
+    ensures Until(proposal, accept)(s) == Monad.Bind(proposal, (x: A) => if accept(x) then Monad.Return(x) else Until(proposal, accept))(s)
+  {
+    var reject := (a: A) => !accept(a);
+    var body := (a: A) => proposal;
+    var (init, s') := proposal(s);
+    WhileUnroll(reject, body, init, s');
+  }
 
   // Equation (3.40)
   lemma EnsureUntilTerminatesAndForAll<A(!new)>(proposal: Monad.Hurd<A>, accept: A -> bool)
     requires Independence.IsIndep(proposal)
     requires Quantifier.WithPosProb(ProposalIsAccepted(proposal, accept))
-    ensures UntilTerminates(proposal, accept)
+    ensures UntilTerminatesAlmostSurely(proposal, accept)
     ensures Quantifier.AlmostSurely(UntilLoopResultIsAccepted(proposal, accept))
   {
     EnsureUntilTerminates(proposal, accept);
@@ -199,23 +300,16 @@ module Loops {
 
   lemma WhileIsIndep<A(!new)>(condition: A -> bool, body: A -> Monad.Hurd<A>, init: A)
     requires forall a: A :: Independence.IsIndep(body(a))
-    requires WhileTerminates(condition, body)
+    requires WhileTerminatesAlmostSurely(condition, body)
     ensures Independence.IsIndep(While(condition, body, init))
   {
-    if condition(init) {
-      forall a ensures Independence.IsIndep(While(condition, body, a)) {
-        assume {:axiom} false; // circular reasoning, rewrite this proof
-        WhileIsIndep(condition, body, a);
-      }
-      Independence.IndepFnIsCompositional(body(init), a => While(condition, body, a));
-    } else {
-      Independence.ReturnIsIndep(init);
-    }
+    // To prove this, we need a definition of Independence.IsIndep
+    assume {:axiom} false;
   }
 
   lemma UntilIsIndep<A(!new)>(proposal: Monad.Hurd<A>, accept: A -> bool)
     requires Independence.IsIndep(proposal)
-    requires UntilTerminates(proposal, accept)
+    requires UntilTerminatesAlmostSurely(proposal, accept)
     ensures Independence.IsIndep(Until(proposal, accept))
   {
     var reject := (a: A) => !accept(a);

--- a/src/ProbabilisticProgramming/Loops.dfy
+++ b/src/ProbabilisticProgramming/Loops.dfy
@@ -19,7 +19,7 @@ module Loops {
       Monad.Return(init)
     else (
            if condition(init) then
-             Monad.Bind(body(init), (a: A) => WhileCut(condition, body, a, fuel - 1))
+             Monad.Bind(body(init), (init': A) => WhileCut(condition, body, init', fuel - 1))
            else
              Monad.Return(init)
          )
@@ -35,9 +35,9 @@ module Loops {
 
   // Definition 39 / True iff Prob(iset s | While(condition, body, a)(s) terminates) == 1
   ghost predicate WhileTerminatesAlmostSurely<A(!new)>(condition: A -> bool, body: A -> Monad.Hurd<A>) {
-    var p := (a: A) =>
-               (s: Rand.Bitstream) => exists n :: !condition(WhileCut(condition, body, a, n)(s).0);
-    forall a :: Quantifier.AlmostSurely(p(a))
+    var p := (init: A) =>
+               (s: Rand.Bitstream) => WhileCutTerminates(condition, body, init, s);
+    forall init :: Quantifier.AlmostSurely(p(init))
   }
 
   // Equation (3.25)


### PR DESCRIPTION
This is a step towards a proper definition of while loops.
Previously, we used a recursive definition, which needed an `assume false` for termination.
This PR changes it to (almost) Hurd's definition, but with a small modification because Dafny does not have an `arb` value like HOL.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
