### PR TITLE
Name the type and fields of the result of a monadic computation on a bitstream

### DIFF
--- a/audit.log
+++ b/audit.log
@@ -1,11 +1,11 @@
 src/Distributions/BernoulliExpNeg/Correctness.dfy(13,17): Correctness: Declaration has explicit `{:axiom}` attribute. 
 src/Distributions/BernoulliExpNeg/Correctness.dfy(17,17): SampleIsIndep: Declaration has explicit `{:axiom}` attribute. 
-src/Distributions/BernoulliExpNeg/Implementation.dfy(34,6): BernoulliExpNegSample: Definition has `assume {:axiom}` statement in body. 
-src/Distributions/BernoulliExpNeg/Implementation.dfy(52,6): BernoulliExpNegSampleCaseLe1: Definition has `assume {:axiom}` statement in body. 
+src/Distributions/BernoulliExpNeg/Implementation.dfy(35,6): BernoulliExpNegSample: Definition has `assume {:axiom}` statement in body. 
+src/Distributions/BernoulliExpNeg/Implementation.dfy(53,6): BernoulliExpNegSampleCaseLe1: Definition has `assume {:axiom}` statement in body. 
 src/Distributions/BernoulliExpNeg/Model.dfy(30,4): GammaReductionLoop: Definition has `assume {:axiom}` statement in body. 
 src/Distributions/BernoulliExpNeg/Model.dfy(60,4): GammaLe1Loop: Definition has `assume {:axiom}` statement in body. 
-src/Distributions/Coin/Interface.dfy(20,6): CoinSample: Definition has `assume {:axiom}` statement in body. 
-src/Distributions/Uniform/Implementation.dfy(44,6): UniformSample: Definition has `assume {:axiom}` statement in body. 
+src/Distributions/Coin/Interface.dfy(21,6): CoinSample: Definition has `assume {:axiom}` statement in body. 
+src/Distributions/Uniform/Implementation.dfy(45,6): UniformSample: Definition has `assume {:axiom}` statement in body. 
 src/Math/Analysis/Reals.dfy(35,17): LeastUpperBoundProperty: Declaration has explicit `{:axiom}` attribute. 
 src/Math/Exponential.dfy(11,17): EvalOne: Declaration has explicit `{:axiom}` attribute. 
 src/Math/Exponential.dfy(2,26): Exp: Declaration has explicit `{:axiom}` attribute. 
@@ -14,9 +14,9 @@ src/Math/Exponential.dfy(7,17): Increasing: Declaration has explicit `{:axiom}` 
 src/Math/Measures.dfy(150,17): CountableSumOfZeroesIsZero: Declaration has explicit `{:axiom}` attribute. 
 src/Math/Measures.dfy(25,4): CountableSum: Definition has `assume {:axiom}` statement in body. 
 src/ProbabilisticProgramming/Independence.dfy(28,27): IsIndep: Declaration has explicit `{:axiom}` attribute. 
-src/ProbabilisticProgramming/Independence.dfy(34,17): IsIndepImpliesFstMeasurableBool: Declaration has explicit `{:axiom}` attribute. 
-src/ProbabilisticProgramming/Independence.dfy(38,17): IsIndepImpliesFstMeasurableNat: Declaration has explicit `{:axiom}` attribute. 
-src/ProbabilisticProgramming/Independence.dfy(42,17): IsIndepImpliesSndMeasurable: Declaration has explicit `{:axiom}` attribute. 
+src/ProbabilisticProgramming/Independence.dfy(34,17): IsIndepImpliesValueMeasurableBool: Declaration has explicit `{:axiom}` attribute. 
+src/ProbabilisticProgramming/Independence.dfy(38,17): IsIndepImpliesValueMeasurableNat: Declaration has explicit `{:axiom}` attribute. 
+src/ProbabilisticProgramming/Independence.dfy(42,17): IsIndepImpliesRestMeasurable: Declaration has explicit `{:axiom}` attribute. 
 src/ProbabilisticProgramming/Independence.dfy(46,17): IsIndepImpliesIsIndepFunction: Declaration has explicit `{:axiom}` attribute. 
 src/ProbabilisticProgramming/Independence.dfy(51,17): CoinIsIndep: Declaration has explicit `{:axiom}` attribute. 
 src/ProbabilisticProgramming/Independence.dfy(55,17): ReturnIsIndep: Declaration has explicit `{:axiom}` attribute. 
@@ -26,7 +26,7 @@ src/ProbabilisticProgramming/Loops.dfy(257,17): EnsureWhileTerminates: Declarati
 src/ProbabilisticProgramming/Loops.dfy(263,17): UntilProbabilityFraction: Declaration has explicit `{:axiom}` attribute. 
 src/ProbabilisticProgramming/Loops.dfy(294,4): EnsureUntilTerminatesAndForAll: Definition has `assume {:axiom}` statement in body. 
 src/ProbabilisticProgramming/Loops.dfy(317,4): WhileIsIndep: Definition has `assume {:axiom}` statement in body. 
-src/ProbabilisticProgramming/Monad.dfy(134,17): CoinHasProbOneHalf: Declaration has explicit `{:axiom}` attribute. 
-src/ProbabilisticProgramming/Monad.dfy(141,17): MeasureHeadDrop: Declaration has explicit `{:axiom}` attribute. 
-src/ProbabilisticProgramming/Monad.dfy(147,17): TailIsMeasurePreserving: Declaration has explicit `{:axiom}` attribute. 
+src/ProbabilisticProgramming/Monad.dfy(140,17): CoinHasProbOneHalf: Declaration has explicit `{:axiom}` attribute. 
+src/ProbabilisticProgramming/Monad.dfy(147,17): MeasureHeadDrop: Declaration has explicit `{:axiom}` attribute. 
+src/ProbabilisticProgramming/Monad.dfy(153,17): TailIsMeasurePreserving: Declaration has explicit `{:axiom}` attribute. 
 src/ProbabilisticProgramming/RandomSource.dfy(25,17): ProbIsProbabilityMeasure: Declaration has explicit `{:axiom}` attribute. 

--- a/src/Distributions/Bernoulli/Correctness.dfy
+++ b/src/Distributions/Bernoulli/Correctness.dfy
@@ -42,18 +42,18 @@ module Bernoulli.Correctness {
     requires n != 0
     requires m <= n
     ensures
-      var e := iset s | Model.Sample(m, n)(s).0;
+      var e := iset s | Model.Sample(m, n)(s).value;
       && e in Rand.eventSpace
       && Rand.prob(e) == m as real / n as real
   {
-    var e := iset s | Model.Sample(m, n)(s).0;
+    var e := iset s | Model.Sample(m, n)(s).value;
 
     if m == 0 {
       assert e == iset{} by {
-        forall s ensures !Model.Sample(m, n)(s).0 {
+        forall s ensures !Model.Sample(m, n)(s).value {
           calc {
-            Model.Sample(m, n)(s).0;
-            Uniform.Model.Sample(n)(s).0 < 0;
+            Model.Sample(m, n)(s).value;
+            Uniform.Model.Sample(n)(s).value < 0;
             false;
           }
         }
@@ -65,13 +65,13 @@ module Bernoulli.Correctness {
         assert Measures.IsPositive(Rand.eventSpace, Rand.prob);
       }
     } else {
-      var e1 := iset s | Uniform.Model.Sample(n)(s).0 == m-1;
-      var e2 := (iset s {:trigger Uniform.Model.Sample(n)(s).0} | Model.Sample(m-1, n)(s).0);
+      var e1 := iset s | Uniform.Model.Sample(n)(s).value == m-1;
+      var e2 := (iset s {:trigger Uniform.Model.Sample(n)(s).value} | Model.Sample(m-1, n)(s).value);
 
-      assert (iset s | Uniform.Model.Sample(n)(s).0 < m-1) == e2 by {
-        assert (iset s | Uniform.Model.Sample(n)(s).0 < m-1) == (iset s {:trigger Uniform.Model.Sample(n)(s).0} | Model.Sample(m-1, n)(s).0) by {
-          forall s ensures Uniform.Model.Sample(n)(s).0 < m-1 <==> Model.Sample(m-1, n)(s).0 {
-            assert Uniform.Model.Sample(n)(s).0 < m-1 <==> Model.Sample(m-1, n)(s).0;
+      assert (iset s | Uniform.Model.Sample(n)(s).value < m-1) == e2 by {
+        assert (iset s | Uniform.Model.Sample(n)(s).value < m-1) == (iset s {:trigger Uniform.Model.Sample(n)(s).value} | Model.Sample(m-1, n)(s).value) by {
+          forall s ensures Uniform.Model.Sample(n)(s).value < m-1 <==> Model.Sample(m-1, n)(s).value {
+            assert Uniform.Model.Sample(n)(s).value < m-1 <==> Model.Sample(m-1, n)(s).value;
           }
         }
       }
@@ -79,9 +79,9 @@ module Bernoulli.Correctness {
       assert e == e1 + e2 by {
         calc {
           e;
-          iset s | Uniform.Model.Sample(n)(s).0 < m;
-          iset s | Uniform.Model.Sample(n)(s).0 == m-1 || Uniform.Model.Sample(n)(s).0 < m-1;
-          (iset s | Uniform.Model.Sample(n)(s).0 == m-1) + (iset s | Uniform.Model.Sample(n)(s).0 < m-1);
+          iset s | Uniform.Model.Sample(n)(s).value < m;
+          iset s | Uniform.Model.Sample(n)(s).value == m-1 || Uniform.Model.Sample(n)(s).value < m-1;
+          (iset s | Uniform.Model.Sample(n)(s).value == m-1) + (iset s | Uniform.Model.Sample(n)(s).value < m-1);
           e1 + e2;
         }
       }

--- a/src/Distributions/Bernoulli/Implementation.dfy
+++ b/src/Distributions/Bernoulli/Implementation.dfy
@@ -5,6 +5,7 @@
 
 module Bernoulli.Implementation {
   import Rationals
+  import Monad
   import Model
   import Interface
 
@@ -14,7 +15,7 @@ module Bernoulli.Implementation {
       modifies this
       decreases *
       requires 0 <= p.numer <= p.denom
-      ensures Model.Sample(p.numer, p.denom)(old(s)) == (c, s)
+      ensures Model.Sample(p.numer, p.denom)(old(s)) == Monad.Result(c, s)
     {
       var k := UniformSample(p.denom);
       c := k < p.numer;

--- a/src/Distributions/Bernoulli/Interface.dfy
+++ b/src/Distributions/Bernoulli/Interface.dfy
@@ -5,6 +5,7 @@
 
 module Bernoulli.Interface {
   import Rationals
+  import Monad
   import Uniform
   import Model
 
@@ -14,7 +15,7 @@ module Bernoulli.Interface {
       modifies this
       decreases *
       requires 0 <= p.numer <= p.denom
-      ensures Model.Sample(p.numer, p.denom)(old(s)) == (c, s)
+      ensures Model.Sample(p.numer, p.denom)(old(s)) == Monad.Result(c, s)
 
   }
 }

--- a/src/Distributions/Bernoulli/Model.dfy
+++ b/src/Distributions/Bernoulli/Model.dfy
@@ -11,8 +11,8 @@ module Bernoulli.Model {
   ghost function Sample(numer: nat, denom: nat): (f: Monad.Hurd<bool>)
     requires denom != 0
     requires numer <= denom
-    ensures forall s :: f(s).0 == (Uniform.Model.Sample(denom)(s).0 < numer)
-    ensures forall s :: f(s).1 == Uniform.Model.Sample(denom)(s).1
+    ensures forall s :: f(s).value == (Uniform.Model.Sample(denom)(s).value < numer)
+    ensures forall s :: f(s).rest == Uniform.Model.Sample(denom)(s).rest
   {
     Monad.Bind(Uniform.Model.Sample(denom), (k: nat) => Monad.Return(k < numer))
   }

--- a/src/Distributions/BernoulliExpNeg/Correctness.dfy
+++ b/src/Distributions/BernoulliExpNeg/Correctness.dfy
@@ -12,7 +12,7 @@ module BernoulliExpNeg.Correctness {
 
   lemma {:axiom} Correctness(gamma: Rationals.Rational)
     requires 0 <= gamma.numer
-    ensures Rand.prob(iset s | Model.Sample(gamma)(s).0) == Exponential.Exp(-Rationals.ToReal(gamma))
+    ensures Rand.prob(iset s | Model.Sample(gamma)(s).value) == Exponential.Exp(-Rationals.ToReal(gamma))
 
   lemma {:axiom} SampleIsIndep(gamma: Rationals.Rational)
     requires 0 <= gamma.numer

--- a/src/Distributions/BernoulliExpNeg/Implementation.dfy
+++ b/src/Distributions/BernoulliExpNeg/Implementation.dfy
@@ -5,6 +5,7 @@
 
 module BernoulliExpNeg.Implementation {
   import Rationals
+  import Monad
   import Interface
   import Model
 
@@ -15,7 +16,7 @@ module BernoulliExpNeg.Implementation {
       modifies this
       requires gamma.numer >= 0
       decreases *
-      ensures (c, s) == Model.Sample(gamma)(old(s))
+      ensures Monad.Result(c, s) == Model.Sample(gamma)(old(s))
     {
       var gamma' := gamma;
       var b := true;
@@ -31,14 +32,14 @@ module BernoulliExpNeg.Implementation {
       } else {
         c := false;
       }
-      assume {:axiom} (c, s) == Model.Sample(gamma)(old(s)); // add later
+      assume {:axiom} Monad.Result(c, s) == Model.Sample(gamma)(old(s)); // add later
     }
 
     method BernoulliExpNegSampleCaseLe1(gamma: Rationals.Rational) returns (c: bool)
       modifies this
       requires 0 <= gamma.numer <= gamma.denom
       decreases *
-      ensures (c, s) == Model.SampleGammaLe1(gamma)(old(s))
+      ensures Monad.Result(c, s) == Model.SampleGammaLe1(gamma)(old(s))
     {
       var k := 0;
       var a := true;
@@ -49,7 +50,7 @@ module BernoulliExpNeg.Implementation {
         a := BernoulliSample(Rationals.Rational(gamma.numer, k * gamma.denom));
       }
       c := k % 2 == 1;
-      assume {:axiom} (c, s) == Model.SampleGammaLe1(gamma)(old(s)); // add later
+      assume {:axiom} Monad.Result(c, s) == Model.SampleGammaLe1(gamma)(old(s)); // add later
     }
 
   }

--- a/src/Distributions/BernoulliExpNeg/Interface.dfy
+++ b/src/Distributions/BernoulliExpNeg/Interface.dfy
@@ -5,6 +5,7 @@
 
 module BernoulliExpNeg.Interface {
   import Rationals
+  import Monad
   import Bernoulli
   import Model
 
@@ -14,7 +15,7 @@ module BernoulliExpNeg.Interface {
       modifies this
       decreases *
       requires gamma.numer >= 0
-      ensures (c, s) == Model.Sample(gamma)(old(s))
+      ensures Monad.Result(c, s) == Model.Sample(gamma)(old(s))
 
   }
 }

--- a/src/Distributions/Coin/Interface.dfy
+++ b/src/Distributions/Coin/Interface.dfy
@@ -4,6 +4,7 @@
  *******************************************************************************/
 
 module Coin.Interface {
+  import Monad
   import Rand
   import Model
 
@@ -14,7 +15,7 @@ module Coin.Interface {
 
     method CoinSample() returns (b: bool)
       modifies this
-      ensures Model.Sample(old(s)) == (b, s)
+      ensures Model.Sample(old(s)) == Monad.Result(b, s)
     {
       b := ExternCoinSample();
       assume {:axiom} false; // assume correctness of extern implementation

--- a/src/Distributions/Coin/Model.dfy
+++ b/src/Distributions/Coin/Model.dfy
@@ -7,7 +7,7 @@ module Coin.Model {
   import Rand
   import Monad
 
-  function Sample(s: Rand.Bitstream): (bool, Rand.Bitstream) {
+  function Sample(s: Rand.Bitstream): Monad.Result<bool> {
     Monad.Coin(s)
   }
 }

--- a/src/Distributions/Uniform/Correctness.dfy
+++ b/src/Distributions/Uniform/Correctness.dfy
@@ -21,7 +21,7 @@ module Uniform.Correctness {
   ghost function SampleEquals(n: nat, i: nat): iset<Rand.Bitstream>
     requires 0 <= i < n
   {
-    iset s | Model.Sample(n)(s).0 == i
+    iset s | Model.Sample(n)(s).value == i
   }
 
   /*******
@@ -91,15 +91,15 @@ module Uniform.Correctness {
         nextPowerOfTwo;
       }
     }
-    assert setEq: Loops.ProposalIsAcceptedAndHasProperty(Model.Proposal(n), Model.Accept(n), (x: nat) => x == i) == (iset s | UniformPowerOfTwo.Model.Sample(2 * n)(s).0 == i) by {
-      forall s ensures s in e <==> UniformPowerOfTwo.Model.Sample(2 * n)(s).0 == i {
-        assert s in e <==> UniformPowerOfTwo.Model.Sample(2 * n)(s).0 == i;
+    assert setEq: Loops.ProposalIsAcceptedAndHasProperty(Model.Proposal(n), Model.Accept(n), (x: nat) => x == i) == (iset s | UniformPowerOfTwo.Model.Sample(2 * n)(s).value == i) by {
+      forall s ensures s in e <==> UniformPowerOfTwo.Model.Sample(2 * n)(s).value == i {
+        assert s in e <==> UniformPowerOfTwo.Model.Sample(2 * n)(s).value == i;
       }
     }
     calc {
       Rand.prob(Loops.ProposalIsAcceptedAndHasProperty(Model.Proposal(n), Model.Accept(n), (x: nat) => x == i));
       { reveal setEq; }
-      Rand.prob(iset s | UniformPowerOfTwo.Model.Sample(2 * n)(s).0 == i);
+      Rand.prob(iset s | UniformPowerOfTwo.Model.Sample(2 * n)(s).value == i);
       { reveal iBound; UniformPowerOfTwo.Correctness.UnifCorrectness2(2 * n, i); }
       1.0 / (nextPowerOfTwo as real);
     }
@@ -112,12 +112,12 @@ module Uniform.Correctness {
   {
     var e := Loops.ProposalAcceptedEvent(Model.Proposal(n), Model.Accept(n));
     assert n < Helper.Power(2, Helper.Log2Floor(2 * n)) by { Helper.NLtPower2Log2FloorOf2N(n); }
-    assert Equal: e == (iset s | UniformPowerOfTwo.Model.Sample(2 * n)(s).0 < n) by {
-      forall s ensures s in e <==> UniformPowerOfTwo.Model.Sample(2 * n)(s).0 < n {
+    assert Equal: e == (iset s | UniformPowerOfTwo.Model.Sample(2 * n)(s).value < n) by {
+      forall s ensures s in e <==> UniformPowerOfTwo.Model.Sample(2 * n)(s).value < n {
         calc {
           s in e;
-          Model.Accept(n)(Model.Proposal(n)(s).0);
-          UniformPowerOfTwo.Model.Sample(2 * n)(s).0 < n;
+          Model.Accept(n)(Model.Proposal(n)(s).value);
+          UniformPowerOfTwo.Model.Sample(2 * n)(s).value < n;
         }
       }
     }
@@ -125,7 +125,7 @@ module Uniform.Correctness {
       calc {
         Rand.prob(e);
         { reveal Equal; }
-        Rand.prob(iset s | UniformPowerOfTwo.Model.Sample(2 * n)(s).0 < n);
+        Rand.prob(iset s | UniformPowerOfTwo.Model.Sample(2 * n)(s).value < n);
         { UniformPowerOfTwo.Correctness.UnifCorrectness2Inequality(2 * n, n); }
         (n as real) / (Helper.Power(2, Helper.Log2Floor(2 * n)) as real);
       }
@@ -136,7 +136,7 @@ module Uniform.Correctness {
   lemma UniformFullIntervalCorrectness(a: int, b: int, i: int)
     requires a <= i < b
     ensures
-      var e := iset s | Model.IntervalSample(a, b)(s).0 == i;
+      var e := iset s | Model.IntervalSample(a, b)(s).value == i;
       && e in Rand.eventSpace
       && Rand.prob(e) == (1.0 / ((b-a) as real))
   {
@@ -146,10 +146,10 @@ module Uniform.Correctness {
     var e' := SampleEquals(b - a, i - a);
     assert e' in Rand.eventSpace by { UniformFullCorrectness(b - a, i - a); }
     assert Rand.prob(e') == (1.0 / ((b-a) as real)) by { UniformFullCorrectness(b - a, i - a); }
-    var e := iset s | Model.IntervalSample(a, b)(s).0 == i;
+    var e := iset s | Model.IntervalSample(a, b)(s).value == i;
     assert e == e' by {
-      forall s ensures Model.IntervalSample(a, b)(s).0 == i <==> Model.Sample(b-a)(s).0 == i - a {
-        assert Model.IntervalSample(a, b)(s).0 == a + Model.Sample(b - a)(s).0;
+      forall s ensures Model.IntervalSample(a, b)(s).value == i <==> Model.Sample(b-a)(s).value == i - a {
+        assert Model.IntervalSample(a, b)(s).value == a + Model.Sample(b - a)(s).value;
       }
     }
   }

--- a/src/Distributions/Uniform/Implementation.dfy
+++ b/src/Distributions/Uniform/Implementation.dfy
@@ -4,6 +4,7 @@
  *******************************************************************************/
 
 module Uniform.Implementation {
+  import Monad
   import UniformPowerOfTwo
   import Model
   import Interface
@@ -14,14 +15,14 @@ module Uniform.Implementation {
       decreases *
       requires n > 0
       ensures u < n
-      ensures Model.Sample(n)(old(s)) == (u, s)
+      ensures Model.Sample(n)(old(s)) == Monad.Result(u, s)
     {
       ghost var prevS := s;
       u := UniformPowerOfTwoSample(2 * n);
       while u >= n
         decreases *
         invariant Model.Sample(n)(old(s)) == Model.Sample(n)(prevS)
-        invariant (u, s) == Model.Proposal(n)(prevS)
+        invariant Monad.Result(u, s) == Model.Proposal(n)(prevS)
       {
         Model.SampleUnroll(n, prevS);
         prevS := s;
@@ -38,7 +39,7 @@ module Uniform.Implementation {
       decreases *
       requires n > 0
       ensures u < n
-      ensures Model.Sample(n)(old(s)) == (u, s)
+      ensures Model.Sample(n)(old(s)) == Monad.Result(u, s)
     {
       u := ExternUniformSample(n);
       assume {:axiom} false; // assume correctness of extern implementation

--- a/src/Distributions/Uniform/Interface.dfy
+++ b/src/Distributions/Uniform/Interface.dfy
@@ -4,6 +4,7 @@
  *******************************************************************************/
 
 module Uniform.Interface {
+  import Monad
   import Coin
   import Model
   import UniformPowerOfTwo
@@ -15,18 +16,18 @@ module Uniform.Interface {
       decreases *
       requires n > 0
       ensures u < n
-      ensures Model.Sample(n)(old(s)) == (u, s)
+      ensures Model.Sample(n)(old(s)) == Monad.Result(u, s)
 
     method UniformIntervalSample(a: int, b: int) returns (u: int)
       modifies this
       decreases *
       requires a < b
       ensures a <= u < b
-      ensures Model.IntervalSample(a, b)(old(s)) == (u, s)
+      ensures Model.IntervalSample(a, b)(old(s)) == Monad.Result(u, s)
     {
       var v := UniformSample(b - a);
-      assert Model.Sample(b-a)(old(s)) == (v, s);
-      assert Model.IntervalSample(a, b)(old(s)) == (a + v, s);
+      assert Model.Sample(b-a)(old(s)) == Monad.Result(v, s);
+      assert Model.IntervalSample(a, b)(old(s)) == Monad.Result(a + v, s);
       u := a + v;
     }
 

--- a/src/Distributions/Uniform/Model.dfy
+++ b/src/Distributions/Uniform/Model.dfy
@@ -53,19 +53,19 @@ module Uniform.Model {
     }
     var e := iset s | Loops.ProposalIsAccepted(Proposal(n), Accept(n))(s);
     assert e in Rand.eventSpace by {
-      assert e == Measures.PreImage(s => UniformPowerOfTwo.Model.Sample(2 * n)(s).0, (iset m: nat | m < n));
-      assert Measures.PreImage(s => UniformPowerOfTwo.Model.Sample(2 * n)(s).0, (iset m: nat | m < n)) in Rand.eventSpace by {
+      assert e == Measures.PreImage(s => UniformPowerOfTwo.Model.Sample(2 * n)(s).value, (iset m: nat | m < n));
+      assert Measures.PreImage(s => UniformPowerOfTwo.Model.Sample(2 * n)(s).value, (iset m: nat | m < n)) in Rand.eventSpace by {
         assert Independence.IsIndep(UniformPowerOfTwo.Model.Sample(2 * n)) by {
           UniformPowerOfTwo.Correctness.SampleIsIndep(2 * n);
         }
-        assert Measures.IsMeasurable(Rand.eventSpace, Measures.natEventSpace, s => UniformPowerOfTwo.Model.Sample(2 * n)(s).0) by {
-          Independence.IsIndepImpliesFstMeasurableNat(UniformPowerOfTwo.Model.Sample(2 * n));
+        assert Measures.IsMeasurable(Rand.eventSpace, Measures.natEventSpace, s => UniformPowerOfTwo.Model.Sample(2 * n)(s).value) by {
+          Independence.IsIndepImpliesValueMeasurableNat(UniformPowerOfTwo.Model.Sample(2 * n));
         }
       }
     }
     assert Quantifier.WithPosProb(Loops.ProposalIsAccepted(Proposal(n), Accept(n))) by {
       assert Rand.prob(e) > 0.0 by {
-        assert e == (iset s | UniformPowerOfTwo.Model.Sample(2 * n)(s).0 < n);
+        assert e == (iset s | UniformPowerOfTwo.Model.Sample(2 * n)(s).value < n);
         assert n <= Helper.Power(2, Helper.Log2Floor(2 * n)) by {
           Helper.NLtPower2Log2FloorOf2N(n);
         }

--- a/src/Distributions/Uniform/Model.dfy
+++ b/src/Distributions/Uniform/Model.dfy
@@ -37,8 +37,8 @@ module Uniform.Model {
     requires a < b
   {
     (s: Rand.Bitstream) =>
-      var (x, s') := Sample(b - a)(s);
-      (a + x, s')
+      var Result(x, s') := Sample(b - a)(s);
+      Monad.Result(a + x, s')
   }
 
   lemma SampleTerminates(n: nat)

--- a/src/Distributions/UniformPowerOfTwo/Correctness.dfy
+++ b/src/Distributions/UniformPowerOfTwo/Correctness.dfy
@@ -247,8 +247,8 @@ module UniformPowerOfTwo.Correctness {
     requires n >= 2
     ensures Model.Sample(n)(s).1 == Monad.Tail(Model.Sample(n / 2)(s).1)
   {
-    var (a, s') := Model.Sample(n / 2)(s);
-    var (b, s'') := Monad.Coin(s');
+    var Result(a, s') := Model.Sample(n / 2)(s);
+    var Result(b, s'') := Monad.Coin(s');
     calc {
       Model.Sample(n)(s).1;
     ==
@@ -278,8 +278,8 @@ module UniformPowerOfTwo.Correctness {
     var bOf := (s: Rand.Bitstream) => Monad.Coin(Model.Sample(n / 2)(s).1).0;
     var aOf := (s: Rand.Bitstream) => Model.Sample(n / 2)(s).0;
     forall s ensures Model.Sample(n)(s).0 == m <==> (2 * aOf(s) + Helper.boolToNat(bOf(s)) == m) {
-      var (a, s') := Model.Sample(n / 2)(s);
-      var (b, s'') := Monad.Coin(s');
+      var Result(a, s') := Model.Sample(n / 2)(s);
+      var Result(b, s'') := Monad.Coin(s');
       calc {
         Model.Sample(n)(s).0;
       ==

--- a/src/Distributions/UniformPowerOfTwo/Correctness.dfy
+++ b/src/Distributions/UniformPowerOfTwo/Correctness.dfy
@@ -20,13 +20,13 @@ module UniformPowerOfTwo.Correctness {
   ghost predicate UnifIsCorrect(n: nat, k: nat, m: nat)
     requires Helper.Power(2, k) <= n < Helper.Power(2, k + 1)
   {
-    Rand.prob(iset s | Model.Sample(n)(s).0 == m) == if m < Helper.Power(2, k) then 1.0 / (Helper.Power(2, k) as real) else 0.0
+    Rand.prob(iset s | Model.Sample(n)(s).value == m) == if m < Helper.Power(2, k) then 1.0 / (Helper.Power(2, k) as real) else 0.0
   }
 
   function Sample1(n: nat): Rand.Bitstream -> Rand.Bitstream
     requires n >= 1
   {
-    (s: Rand.Bitstream) => Model.Sample(n)(s).1
+    (s: Rand.Bitstream) => Model.Sample(n)(s).rest
   }
 
   /*******
@@ -39,20 +39,20 @@ module UniformPowerOfTwo.Correctness {
   lemma UnifCorrectness2(n: nat, m: nat)
     requires n >= 1
     ensures
-      var e := iset s | Model.Sample(n)(s).0 == m;
+      var e := iset s | Model.Sample(n)(s).value == m;
       && e in Rand.eventSpace
       && Rand.prob(e) == if m < Helper.Power(2, Helper.Log2Floor(n)) then 1.0 / (Helper.Power(2, Helper.Log2Floor(n)) as real) else 0.0
   {
-    var e := iset s | Model.Sample(n)(s).0 == m;
+    var e := iset s | Model.Sample(n)(s).value == m;
     var k := Helper.Log2Floor(n);
 
     assert e in Rand.eventSpace by {
       assert iset{m} in Measures.natEventSpace;
-      var preimage := Measures.PreImage((s: Rand.Bitstream) => Model.Sample(n)(s).0, iset{m});
+      var preimage := Measures.PreImage((s: Rand.Bitstream) => Model.Sample(n)(s).value, iset{m});
       assert preimage in Rand.eventSpace by {
-        assert Measures.IsMeasurable(Rand.eventSpace, Measures.natEventSpace, s => Model.Sample(n)(s).0) by {
+        assert Measures.IsMeasurable(Rand.eventSpace, Measures.natEventSpace, s => Model.Sample(n)(s).value) by {
           SampleIsIndep(n);
-          Independence.IsIndepImpliesFstMeasurableNat(Model.Sample(n));
+          Independence.IsIndepImpliesValueMeasurableNat(Model.Sample(n));
         }
       }
       assert e == preimage;
@@ -67,18 +67,18 @@ module UniformPowerOfTwo.Correctness {
     requires n >= 1
     requires m <= Helper.Power(2, Helper.Log2Floor(n))
     ensures
-      var e := iset s | Model.Sample(n)(s).0 < m;
+      var e := iset s | Model.Sample(n)(s).value < m;
       && e in Rand.eventSpace
       && Rand.prob(e) == (m as real) / (Helper.Power(2, Helper.Log2Floor(n)) as real)
   {
-    var e := iset s | Model.Sample(n)(s).0 < m;
+    var e := iset s | Model.Sample(n)(s).value < m;
 
     if m == 0 {
       assert e == iset{};
       Rand.ProbIsProbabilityMeasure();
     } else {
-      var e1 := iset s | Model.Sample(n)(s).0 < m-1;
-      var e2 := iset s | Model.Sample(n)(s).0 == m-1;
+      var e1 := iset s | Model.Sample(n)(s).value < m-1;
+      var e2 := iset s | Model.Sample(n)(s).value == m-1;
       assert e1 in Rand.eventSpace by {
         UnifCorrectness2Inequality(n, m-1);
       }
@@ -117,9 +117,9 @@ module UniformPowerOfTwo.Correctness {
       assert n >= 1 by { Helper.PowerGreater0(2, k); }
       if k == 0 {
         if m == 0 {
-          assert (iset s | Model.Sample(1)(s).0 == m) == (iset s);
+          assert (iset s | Model.Sample(1)(s).value == m) == (iset s);
         } else {
-          assert (iset s | Model.Sample(1)(s).0 == m) == iset{};
+          assert (iset s | Model.Sample(1)(s).value == m) == iset{};
         }
         Rand.ProbIsProbabilityMeasure();
         assert UnifIsCorrect(n, k, m);
@@ -130,9 +130,9 @@ module UniformPowerOfTwo.Correctness {
         }
         if m < Helper.Power(2, k) {
           calc {
-            Rand.prob(iset s | Model.Sample(n)(s).0 == m);
+            Rand.prob(iset s | Model.Sample(n)(s).value == m);
           == { SampleRecursiveHalf(n, m); }
-            Rand.prob(iset s | Model.Sample(n / 2)(s).0 == u) / 2.0;
+            Rand.prob(iset s | Model.Sample(n / 2)(s).value == u) / 2.0;
           == { reveal RecursiveCorrect; }
             (1.0 / Helper.Power(2, k - 1) as real) / 2.0;
           == { Helper.PowerOfTwoLemma(k - 1); }
@@ -141,9 +141,9 @@ module UniformPowerOfTwo.Correctness {
           assert UnifIsCorrect(n, k, m);
         } else {
           calc {
-            Rand.prob(iset s | Model.Sample(n)(s).0 == m);
+            Rand.prob(iset s | Model.Sample(n)(s).value == m);
           == { SampleRecursiveHalf(n, m); }
-            Rand.prob(iset s | Model.Sample(n / 2)(s).0 == u) / 2.0;
+            Rand.prob(iset s | Model.Sample(n / 2)(s).value == u) / 2.0;
           == { reveal RecursiveCorrect; }
             0.0 / 2.0;
           ==
@@ -187,7 +187,7 @@ module UniformPowerOfTwo.Correctness {
     var f := Sample1(n);
     assert Measures.IsMeasurable(Rand.eventSpace, Rand.eventSpace, f) by {
       SampleIsIndep(n);
-      Independence.IsIndepImpliesSndMeasurable(Model.Sample(n));
+      Independence.IsIndepImpliesRestMeasurable(Model.Sample(n));
       assert Independence.IsIndep(Model.Sample(n));
     }
     if n == 1 {
@@ -212,13 +212,13 @@ module UniformPowerOfTwo.Correctness {
             forall s ensures f(s) in e <==> g(s) in e' {
               calc {
                 f(s) in e;
-              <==> { assert f(s) == Model.Sample(n)(s).1; }
-                Model.Sample(n)(s).1 in e;
+              <==> { assert f(s) == Model.Sample(n)(s).rest; }
+                Model.Sample(n)(s).rest in e;
               <==> { SampleTailDecompose(n, s); }
-                Monad.Tail(Model.Sample(n / 2)(s).1) in e;
+                Monad.Tail(Model.Sample(n / 2)(s).rest) in e;
               <==>
-                Model.Sample(n / 2)(s).1 in e';
-              <==> { assert Model.Sample(n / 2)(s).1 == g(s); }
+                Model.Sample(n / 2)(s).rest in e';
+              <==> { assert Model.Sample(n / 2)(s).rest == g(s); }
                 g(s) in e';
               }
             }
@@ -245,51 +245,51 @@ module UniformPowerOfTwo.Correctness {
 
   lemma SampleTailDecompose(n: nat, s: Rand.Bitstream)
     requires n >= 2
-    ensures Model.Sample(n)(s).1 == Monad.Tail(Model.Sample(n / 2)(s).1)
+    ensures Model.Sample(n)(s).rest == Monad.Tail(Model.Sample(n / 2)(s).rest)
   {
     var Result(a, s') := Model.Sample(n / 2)(s);
     var Result(b, s'') := Monad.Coin(s');
     calc {
-      Model.Sample(n)(s).1;
+      Model.Sample(n)(s).rest;
     ==
-      Monad.Bind(Model.Sample(n / 2), Model.UnifStep)(s).1;
+      Monad.Bind(Model.Sample(n / 2), Model.UnifStep)(s).rest;
     ==
-      Model.UnifStep(a)(s').1;
+      Model.UnifStep(a)(s').rest;
     ==
-      Monad.Bind(Monad.Coin, (b: bool) => Monad.Return((if b then 2*a + 1 else 2*a) as nat))(s').1;
+      Monad.Bind(Monad.Coin, (b: bool) => Monad.Return((if b then 2*a + 1 else 2*a) as nat))(s').rest;
     ==
-      Monad.Return((if b then 2*a + 1 else 2*a) as nat)(s'').1;
+      Monad.Return((if b then 2*a + 1 else 2*a) as nat)(s'').rest;
     ==
       s'';
     ==
       Monad.Tail(s');
     ==
-      Monad.Tail(Model.Sample(n / 2)(s).1);
+      Monad.Tail(Model.Sample(n / 2)(s).rest);
     }
   }
 
   lemma SampleSetEquality(n: nat, m: nat)
     requires n >= 2
     ensures
-      var bOf := (s: Rand.Bitstream) => Monad.Coin(Model.Sample(n / 2)(s).1).0;
-      var aOf := (s: Rand.Bitstream) => Model.Sample(n / 2)(s).0;
-      (iset s | Model.Sample(n)(s).0 == m) == (iset s | 2*aOf(s) + Helper.boolToNat(bOf(s)) == m)
+      var bOf := (s: Rand.Bitstream) => Monad.Coin(Model.Sample(n / 2)(s).rest).value;
+      var aOf := (s: Rand.Bitstream) => Model.Sample(n / 2)(s).value;
+      (iset s | Model.Sample(n)(s).value == m) == (iset s | 2*aOf(s) + Helper.boolToNat(bOf(s)) == m)
   {
-    var bOf := (s: Rand.Bitstream) => Monad.Coin(Model.Sample(n / 2)(s).1).0;
-    var aOf := (s: Rand.Bitstream) => Model.Sample(n / 2)(s).0;
-    forall s ensures Model.Sample(n)(s).0 == m <==> (2 * aOf(s) + Helper.boolToNat(bOf(s)) == m) {
+    var bOf := (s: Rand.Bitstream) => Monad.Coin(Model.Sample(n / 2)(s).rest).value;
+    var aOf := (s: Rand.Bitstream) => Model.Sample(n / 2)(s).value;
+    forall s ensures Model.Sample(n)(s).value == m <==> (2 * aOf(s) + Helper.boolToNat(bOf(s)) == m) {
       var Result(a, s') := Model.Sample(n / 2)(s);
       var Result(b, s'') := Monad.Coin(s');
       calc {
-        Model.Sample(n)(s).0;
+        Model.Sample(n)(s).value;
       ==
-        Monad.Bind(Model.Sample(n / 2), Model.UnifStep)(s).0;
+        Monad.Bind(Model.Sample(n / 2), Model.UnifStep)(s).value;
       ==
-        Model.UnifStep(a)(s').0;
+        Model.UnifStep(a)(s').value;
       ==
-        Monad.Bind(Monad.Coin, b => Monad.Return((if b then 2*a + 1 else 2*a) as nat))(s').0;
+        Monad.Bind(Monad.Coin, b => Monad.Return((if b then 2*a + 1 else 2*a) as nat))(s').value;
       ==
-        Monad.Return((if b then 2*a + 1 else 2*a) as nat)(s'').0;
+        Monad.Return((if b then 2*a + 1 else 2*a) as nat)(s'').value;
       ==
         if b then 2*a + 1 else 2*a;
       }
@@ -298,16 +298,16 @@ module UniformPowerOfTwo.Correctness {
 
   lemma SampleRecursiveHalf(n: nat, m: nat)
     requires n >= 2
-    ensures Rand.prob(iset s | Model.Sample(n)(s).0 == m) == Rand.prob(iset s | Model.Sample(n / 2)(s).0 == m / 2) / 2.0
+    ensures Rand.prob(iset s | Model.Sample(n)(s).value == m) == Rand.prob(iset s | Model.Sample(n / 2)(s).value == m / 2) / 2.0
   {
-    var aOf: Rand.Bitstream -> nat := (s: Rand.Bitstream) => Model.Sample(n / 2)(s).0;
-    var bOf: Rand.Bitstream -> bool := (s: Rand.Bitstream) => Monad.Coin(Model.Sample(n / 2)(s).1).0;
+    var aOf: Rand.Bitstream -> nat := (s: Rand.Bitstream) => Model.Sample(n / 2)(s).value;
+    var bOf: Rand.Bitstream -> bool := (s: Rand.Bitstream) => Monad.Coin(Model.Sample(n / 2)(s).rest).value;
     var A: iset<nat> := (iset x: nat | x == m / 2);
-    var E: iset<Rand.Bitstream> := (iset s | m % 2 as nat == Helper.boolToNat(Monad.Coin(s).0));
-    var f := (s: Rand.Bitstream) => Model.Sample(n / 2)(s).1;
+    var E: iset<Rand.Bitstream> := (iset s | m % 2 as nat == Helper.boolToNat(Monad.Coin(s).value));
+    var f := (s: Rand.Bitstream) => Model.Sample(n / 2)(s).rest;
 
-    var e1 := (iset s | Model.Sample(n / 2)(s).1 in E);
-    var e2 := (iset s | Model.Sample(n / 2)(s).0 in A);
+    var e1 := (iset s | Model.Sample(n / 2)(s).rest in E);
+    var e2 := (iset s | Model.Sample(n / 2)(s).value in A);
     var e3 := (iset s | 2*aOf(s) + Helper.boolToNat(bOf(s)) == m);
 
     assert SplitEvent: e3 == e1 * e2 by {
@@ -326,18 +326,18 @@ module UniformPowerOfTwo.Correctness {
     }
 
     assert Eq2: (iset s | aOf(s) == m / 2) == e2 by {
-      forall s ensures aOf(s) == m / 2 <==> Model.Sample(n / 2)(s).0 in A {
+      forall s ensures aOf(s) == m / 2 <==> Model.Sample(n / 2)(s).value in A {
       }
     }
 
-    assert Eq3: (iset s | aOf(s) == m / 2) == (iset s | Model.Sample(n / 2)(s).0 == m / 2) by {
-      forall s ensures aOf(s) == m / 2 <==> Model.Sample(n / 2)(s).0 == m / 2 {
-        assert aOf(s) == Model.Sample(n / 2)(s).0;
+    assert Eq3: (iset s | aOf(s) == m / 2) == (iset s | Model.Sample(n / 2)(s).value == m / 2) by {
+      forall s ensures aOf(s) == m / 2 <==> Model.Sample(n / 2)(s).value == m / 2 {
+        assert aOf(s) == Model.Sample(n / 2)(s).value;
       }
     }
 
     assert Eq4: e1 == Measures.PreImage(f, E) by {
-      forall s ensures Model.Sample(n / 2)(s).1 in E <==> f(s) in E {
+      forall s ensures Model.Sample(n / 2)(s).rest in E <==> f(s) in E {
       }
     }
 
@@ -373,7 +373,7 @@ module UniformPowerOfTwo.Correctness {
     }
 
     calc {
-      Rand.prob(iset s | Model.Sample(n)(s).0 == m);
+      Rand.prob(iset s | Model.Sample(n)(s).value == m);
     == { SampleSetEquality(n, m); }
       Rand.prob(e3);
     == { reveal SplitEvent; }
@@ -387,7 +387,7 @@ module UniformPowerOfTwo.Correctness {
     == { reveal Eq2; }
       Rand.prob(iset s | aOf(s) == m / 2) / 2.0;
     == { reveal Eq3; }
-      Rand.prob(iset s | Model.Sample(n / 2)(s).0 == m / 2) / 2.0;
+      Rand.prob(iset s | Model.Sample(n / 2)(s).value == m / 2) / 2.0;
     }
   }
 }

--- a/src/Distributions/UniformPowerOfTwo/Implementation.dfy
+++ b/src/Distributions/UniformPowerOfTwo/Implementation.dfy
@@ -4,6 +4,7 @@
  *******************************************************************************/
 
 module UniformPowerOfTwo.Implementation {
+  import Monad
   import Model
   import Interface
 
@@ -11,7 +12,7 @@ module UniformPowerOfTwo.Implementation {
     method UniformPowerOfTwoSample(n: nat) returns (u: nat)
       requires n >= 1
       modifies this
-      ensures Model.Sample(n)(old(s)) == (u, s)
+      ensures Model.Sample(n)(old(s)) == Monad.Result(u, s)
     {
       u := 0;
       var n' := n;

--- a/src/Distributions/UniformPowerOfTwo/Interface.dfy
+++ b/src/Distributions/UniformPowerOfTwo/Interface.dfy
@@ -4,6 +4,7 @@
  *******************************************************************************/
 
 module UniformPowerOfTwo.Interface {
+  import Monad
   import Coin
   import Model
 
@@ -13,7 +14,7 @@ module UniformPowerOfTwo.Interface {
     method UniformPowerOfTwoSample(n: nat) returns (u: nat)
       requires n >= 1
       modifies this
-      ensures Model.Sample(n)(old(s)) == (u, s)
+      ensures Model.Sample(n)(old(s)) == Monad.Result(u, s)
 
   }
 }

--- a/src/Distributions/UniformPowerOfTwo/Model.dfy
+++ b/src/Distributions/UniformPowerOfTwo/Model.dfy
@@ -36,7 +36,7 @@ module UniformPowerOfTwo.Model {
   {
     (s: Rand.Bitstream) =>
       if n == 1 then
-        (u, s)
+        Monad.Result(u, s)
       else
         SampleTailRecursive(n / 2, if Monad.Head(s) then 2*u + 1 else 2*u)(Monad.Tail(s))
   }
@@ -118,7 +118,7 @@ module UniformPowerOfTwo.Model {
     if l == 0 {
       calc {
         Monad.Bind(Sample(Helper.Power(2, m)), (u: nat) => SampleTailRecursive(Helper.Power(2, l), u))(s);
-        (var (u, s') := Sample(Helper.Power(2, m))(s); SampleTailRecursive(1, u)(s'));
+        (var Result(u, s') := Sample(Helper.Power(2, m))(s); SampleTailRecursive(1, u)(s'));
         Sample(Helper.Power(2, m + l))(s);
       }
     } else {
@@ -127,15 +127,15 @@ module UniformPowerOfTwo.Model {
       assert L1GreaterZero: Helper.Power(2, l - 1) >= 1 by { Helper.PowerGreater0(2, l - 1); }
       calc {
         Monad.Bind(Sample(Helper.Power(2, m)), (u: nat) => SampleTailRecursive(Helper.Power(2, l), u))(s);
-        (var (u, s') := Sample(Helper.Power(2, m))(s); SampleTailRecursive(Helper.Power(2, l), u)(s'));
+        (var Result(u, s') := Sample(Helper.Power(2, m))(s); SampleTailRecursive(Helper.Power(2, l), u)(s'));
         { reveal LGreaterZero; }
-        (var (u, s') := Sample(Helper.Power(2, m))(s);
+        (var Result(u, s') := Sample(Helper.Power(2, m))(s);
          SampleTailRecursive(Helper.Power(2, l) / 2, if Monad.Head(s') then 2 * u + 1 else 2 * u)(Monad.Tail(s')));
         { assert Helper.Power(2, l) / 2 == Helper.Power(2, l - 1); reveal L1GreaterZero; }
-        (var (u', s') := Monad.Bind(Sample(Helper.Power(2, m)), UnifStep)(s);
+        (var Result(u', s') := Monad.Bind(Sample(Helper.Power(2, m)), UnifStep)(s);
          SampleTailRecursive(Helper.Power(2, l - 1), u')(s'));
         { assert Helper.Power(2, m + 1) / 2 == Helper.Power(2, m); }
-        (var (u', s') := Sample(Helper.Power(2, m + 1))(s);
+        (var Result(u', s') := Sample(Helper.Power(2, m + 1))(s);
          SampleTailRecursive(Helper.Power(2, l - 1), u')(s'));
         Monad.Bind(Sample(Helper.Power(2, m + 1)), (u: nat) => SampleTailRecursive(Helper.Power(2, l - 1), u))(s);
         { RelateWithTailRecursive(l - 1, m + 1, s); }

--- a/src/ProbabilisticProgramming/Independence.dfy
+++ b/src/ProbabilisticProgramming/Independence.dfy
@@ -14,8 +14,8 @@ module Independence {
 
   // Definition 33
   ghost predicate IsIndepFunctionCondition<A(!new)>(f: Monad.Hurd<A>, A: iset<A>, E: iset<Rand.Bitstream>) {
-    var e1 := iset s | f(s).1 in E;
-    var e2 := iset s | f(s).0 in A;
+    var e1 := iset s | f(s).rest in E;
+    var e2 := iset s | f(s).value in A;
     Measures.AreIndepEvents(Rand.eventSpace, Rand.prob, e1, e2)
   }
 
@@ -31,17 +31,17 @@ module Independence {
    Lemmas
   *******/
 
-  lemma {:axiom} IsIndepImpliesFstMeasurableBool(f: Monad.Hurd<bool>)
+  lemma {:axiom} IsIndepImpliesValueMeasurableBool(f: Monad.Hurd<bool>)
     requires IsIndep(f)
-    ensures Measures.IsMeasurable(Rand.eventSpace, Measures.boolEventSpace, s => f(s).0)
+    ensures Measures.IsMeasurable(Rand.eventSpace, Measures.boolEventSpace, s => f(s).value)
 
-  lemma {:axiom} IsIndepImpliesFstMeasurableNat(f: Monad.Hurd<nat>)
+  lemma {:axiom} IsIndepImpliesValueMeasurableNat(f: Monad.Hurd<nat>)
     requires IsIndep(f)
-    ensures Measures.IsMeasurable(Rand.eventSpace, Measures.natEventSpace, s => f(s).0)
+    ensures Measures.IsMeasurable(Rand.eventSpace, Measures.natEventSpace, s => f(s).value)
 
-  lemma {:axiom} IsIndepImpliesSndMeasurable<A(!new)>(f: Monad.Hurd<A>)
+  lemma {:axiom} IsIndepImpliesRestMeasurable<A(!new)>(f: Monad.Hurd<A>)
     requires IsIndep(f)
-    ensures Measures.IsMeasurable(Rand.eventSpace, Rand.eventSpace, s => f(s).1)
+    ensures Measures.IsMeasurable(Rand.eventSpace, Rand.eventSpace, s => f(s).rest)
 
   lemma {:axiom} IsIndepImpliesIsIndepFunction<A(!new)>(f: Monad.Hurd<A>)
     requires IsIndep(f)

--- a/src/ProbabilisticProgramming/Loops.dfy
+++ b/src/ProbabilisticProgramming/Loops.dfy
@@ -46,7 +46,7 @@ module Loops {
         WhileCut(condition, body, init, fuel)(s)
       else
         // In HOL, Hurd returns `arb` here, which is not possible in Dafny.
-        (init, s)
+        Monad.Result(init, s)
   }
 
   ghost function LeastFuel<A>(condition: A -> bool, body: A -> Monad.Hurd<A>, init: A, s: Rand.Bitstream): (fuel: nat)
@@ -132,7 +132,7 @@ module Loops {
     requires WhileCutTerminates(condition, body, init', s')
     requires LeastFuel(condition, body, init', s') == fuel'
     requires condition(init)
-    requires body(init)(s) == (init', s')
+    requires body(init)(s) == Monad.Result(init', s')
     ensures WhileCutTerminates(condition, body, init, s)
     ensures LeastFuel(condition, body, init, s) == fuel' + 1
   {
@@ -148,21 +148,21 @@ module Loops {
 
   lemma WhileCutUnroll<A>(condition: A -> bool, body: A -> Monad.Hurd<A>, init: A, s: Rand.Bitstream, init': A, s': Rand.Bitstream, fuel: nat)
     requires condition(init)
-    requires body(init)(s) == (init', s')
+    requires body(init)(s) == Monad.Result(init', s')
     ensures WhileCut(condition, body, init, fuel + 1)(s) == WhileCut(condition, body, init', fuel)(s')
   {}
 
 
   lemma WhileCutTerminatesWithFuelUnroll<A>(condition: A -> bool, body: A -> Monad.Hurd<A>, init: A, s: Rand.Bitstream, init': A, s': Rand.Bitstream, fuel: nat)
     requires condition(init)
-    requires body(init)(s) == (init', s')
+    requires body(init)(s) == Monad.Result(init', s')
     ensures WhileCutTerminatesWithFuel(condition, body, init, s)(fuel + 1) == WhileCutTerminatesWithFuel(condition, body, init', s')(fuel)
   {}
 
-  lemma WhileUnrollIfConditionSatisfied<A>(condition: A -> bool, body: A -> Monad.Hurd<A>, init: A, s: Rand.Bitstream, init': A, s': Rand.Bitstream, loop: (A, Rand.Bitstream), unrolled: (A, Rand.Bitstream))
+  lemma WhileUnrollIfConditionSatisfied<A>(condition: A -> bool, body: A -> Monad.Hurd<A>, init: A, s: Rand.Bitstream, init': A, s': Rand.Bitstream, loop: Monad.Result<A>, unrolled: Monad.Result<A>)
     requires WhileCutTerminates(condition, body, init, s)
     requires condition(init)
-    requires body(init)(s) == (init', s')
+    requires body(init)(s) == Monad.Result(init', s')
     requires loop == While(condition, body, init)(s)
     requires unrolled == While(condition, body, init')(s')
     ensures loop == unrolled
@@ -187,7 +187,7 @@ module Loops {
     }
   }
 
-  lemma WhileUnrollIfTerminates<A>(condition: A -> bool, body: A -> Monad.Hurd<A>, init: A, s: Rand.Bitstream, fuel: nat, loop: (A, Rand.Bitstream), unrolled: (A, Rand.Bitstream))
+  lemma WhileUnrollIfTerminates<A>(condition: A -> bool, body: A -> Monad.Hurd<A>, init: A, s: Rand.Bitstream, fuel: nat, loop: Monad.Result<A>, unrolled: Monad.Result<A>)
     requires WhileCutTerminates(condition, body, init, s)
     requires fuel == LeastFuel(condition, body, init, s)
     requires loop == While(condition, body, init)(s)
@@ -195,7 +195,7 @@ module Loops {
     ensures loop == unrolled
   {
     if condition(init) {
-      var (init', s') := body(init)(s);
+      var Result(init', s') := body(init)(s);
       calc {
         loop;
         { WhileUnrollIfConditionSatisfied(condition, body, init, s, init', s', loop, unrolled); }
@@ -205,7 +205,7 @@ module Loops {
     } else {
       calc {
         loop;
-        (init, s);
+        Monad.Result(init, s);
         unrolled;
       }
     }
@@ -279,7 +279,7 @@ module Loops {
   {
     var reject := (a: A) => !accept(a);
     var body := (a: A) => proposal;
-    var (init, s') := proposal(s);
+    var Result(init, s') := proposal(s);
     WhileUnroll(reject, body, init, s');
   }
 

--- a/src/ProbabilisticProgramming/Loops.dfy
+++ b/src/ProbabilisticProgramming/Loops.dfy
@@ -26,7 +26,7 @@ module Loops {
   }
 
   ghost function WhileCutTerminatesWithFuel<A>(condition: A -> bool, body: A -> Monad.Hurd<A>, init: A, s: Rand.Bitstream): nat -> bool {
-    (fuel: nat) => !condition(WhileCut(condition, body, init, fuel)(s).0)
+    (fuel: nat) => !condition(WhileCut(condition, body, init, fuel)(s).value)
   }
 
   // Definition 39 / True iff Prob(iset s | While(condition, body, a)(s) terminates) == 1
@@ -83,7 +83,7 @@ module Loops {
     ensures
       var reject := (a: A) => !accept(a);
       var body := (a: A) => proposal;
-      forall s :: f(s) == While(reject, body, proposal(s).0)(proposal(s).1)
+      forall s :: f(s) == While(reject, body, proposal(s).value)(proposal(s).rest)
   {
     var reject := (a: A) => !accept(a);
     var body := (a: A) => proposal;
@@ -92,35 +92,35 @@ module Loops {
 
   function WhileLoopExitsAfterOneIteration<A(!new)>(body: A -> Monad.Hurd<A>, condition: A -> bool, init: A): (Rand.Bitstream -> bool) {
     (s: Rand.Bitstream) =>
-      !condition(body(init)(s).0)
+      !condition(body(init)(s).value)
   }
 
   function ProposalIsAccepted<A(!new)>(proposal: Monad.Hurd<A>, accept: A -> bool): (Rand.Bitstream -> bool) {
     (s: Rand.Bitstream) =>
-      accept(proposal(s).0)
+      accept(proposal(s).value)
   }
 
   ghost function UntilLoopResultIsAccepted<A>(proposal: Monad.Hurd<A>, accept: A -> bool): (Rand.Bitstream -> bool)
     requires UntilTerminatesAlmostSurely(proposal, accept)
   {
     (s: Rand.Bitstream) =>
-      accept(Until(proposal, accept)(s).0)
+      accept(Until(proposal, accept)(s).value)
   }
 
   ghost function UntilLoopResultHasProperty<A>(proposal: Monad.Hurd<A>, accept: A -> bool, property: A -> bool): iset<Rand.Bitstream>
     requires UntilTerminatesAlmostSurely(proposal, accept)
   {
-    iset s | property(Until(proposal, accept)(s).0)
+    iset s | property(Until(proposal, accept)(s).value)
   }
 
   ghost function ProposalIsAcceptedAndHasProperty<A>(proposal: Monad.Hurd<A>, accept: A -> bool, property: A -> bool): iset<Rand.Bitstream>
   {
-    iset s | property(proposal(s).0) && accept(proposal(s).0)
+    iset s | property(proposal(s).value) && accept(proposal(s).value)
   }
 
   ghost function ProposalAcceptedEvent<A>(proposal: Monad.Hurd<A>, accept: A -> bool): iset<Rand.Bitstream>
   {
-    iset s | accept(proposal(s).0)
+    iset s | accept(proposal(s).value)
   }
 
 
@@ -233,12 +233,12 @@ module Loops {
 
   lemma EnsureUntilTerminates<A(!new)>(proposal: Monad.Hurd<A>, accept: A -> bool)
     requires Independence.IsIndep(proposal)
-    requires Quantifier.WithPosProb((s: Rand.Bitstream) => accept(proposal(s).0))
+    requires Quantifier.WithPosProb((s: Rand.Bitstream) => accept(proposal(s).value))
     ensures UntilTerminatesAlmostSurely(proposal, accept)
   {
     var reject := (a: A) => !accept(a);
     var body := (a: A) => proposal;
-    var proposalIsAccepted := (s: Rand.Bitstream) => accept(proposal(s).0);
+    var proposalIsAccepted := (s: Rand.Bitstream) => accept(proposal(s).value);
     assert UntilTerminatesAlmostSurely(proposal, accept) by {
       forall a: A ensures Independence.IsIndep(body(a)) {
         assert body(a) == proposal;

--- a/src/ProbabilisticProgramming/Monad.dfy
+++ b/src/ProbabilisticProgramming/Monad.dfy
@@ -11,9 +11,13 @@ module Monad {
    Definitions
   ************/
 
-  datatype Result<A> = Result(0: A, 1: Rand.Bitstream)
-
+  // The type (monad) of probabilistic computations (cf. Joe Hurd's PhD thesis).
+  // For a given stream of bits (coin flips), it yields the result of the computation.
   type Hurd<A> = Rand.Bitstream -> Result<A>
+
+  // The result of a probabilistic computation on a bitstream.
+  // It consists of the computed value and the (unconsumed) rest of the bitstream.
+  datatype Result<A> = Result(value: A, rest: Rand.Bitstream)
 
   // Equation (2.38)
   function Tail(s: Rand.Bitstream): (s': Rand.Bitstream) {


### PR DESCRIPTION
This should make models and proofs easier to read. Concretely, this PR does the following:
* Introduce a type `datatype Result<A> = Result(value: A, rest: Rand.Bitstream)`
* Change the definition of `Hurd` from `type Hurd<A> = Rand.Bitstream -> (A, Rand.Bitstream)` to `type Hurd<A> = Rand.Bitstream -> Result<A>`

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).
