### PR TITLE
Model nontermination explicitly ("partial Hurd monad")

### DIFF
--- a/audit.log
+++ b/audit.log
@@ -8,21 +8,19 @@ src/Math/Exponential.dfy(11,17): EvalOne: Declaration has explicit `{:axiom}` at
 src/Math/Exponential.dfy(2,26): Exp: Declaration has explicit `{:axiom}` attribute. 
 src/Math/Exponential.dfy(4,17): FunctionalEquation: Declaration has explicit `{:axiom}` attribute. 
 src/Math/Exponential.dfy(7,17): Increasing: Declaration has explicit `{:axiom}` attribute. 
-src/Math/Measures.dfy(150,17): CountableSumOfZeroesIsZero: Declaration has explicit `{:axiom}` attribute. 
+src/Math/Measures.dfy(169,17): CountableSumOfZeroesIsZero: Declaration has explicit `{:axiom}` attribute. 
 src/Math/Measures.dfy(25,4): CountableSum: Definition has `assume {:axiom}` statement in body. 
 src/ProbabilisticProgramming/Independence.dfy(28,27): IsIndep: Declaration has explicit `{:axiom}` attribute. 
-src/ProbabilisticProgramming/Independence.dfy(34,17): IsIndepImpliesValueMeasurableBool: Declaration has explicit `{:axiom}` attribute. 
-src/ProbabilisticProgramming/Independence.dfy(38,17): IsIndepImpliesValueMeasurableNat: Declaration has explicit `{:axiom}` attribute. 
-src/ProbabilisticProgramming/Independence.dfy(42,17): IsIndepImpliesRestMeasurable: Declaration has explicit `{:axiom}` attribute. 
-src/ProbabilisticProgramming/Independence.dfy(46,17): IsIndepImpliesIsIndepFunction: Declaration has explicit `{:axiom}` attribute. 
-src/ProbabilisticProgramming/Independence.dfy(51,17): CoinIsIndep: Declaration has explicit `{:axiom}` attribute. 
-src/ProbabilisticProgramming/Independence.dfy(55,17): ReturnIsIndep: Declaration has explicit `{:axiom}` attribute. 
-src/ProbabilisticProgramming/Independence.dfy(59,17): BindIsIndep: Declaration has explicit `{:axiom}` attribute. 
-src/ProbabilisticProgramming/Loops.dfy(237,8): WhileUnroll: Definition has `assume {:axiom}` statement in body. 
-src/ProbabilisticProgramming/Loops.dfy(265,17): EnsureWhileTerminates: Declaration has explicit `{:axiom}` attribute. 
-src/ProbabilisticProgramming/Loops.dfy(271,17): UntilProbabilityFraction: Declaration has explicit `{:axiom}` attribute. 
-src/ProbabilisticProgramming/Loops.dfy(302,4): EnsureUntilTerminatesAndForAll: Definition has `assume {:axiom}` statement in body. 
-src/ProbabilisticProgramming/Loops.dfy(325,4): WhileIsIndep: Definition has `assume {:axiom}` statement in body. 
+src/ProbabilisticProgramming/Independence.dfy(34,17): IsIndepImpliesMeasurableBool: Declaration has explicit `{:axiom}` attribute. 
+src/ProbabilisticProgramming/Independence.dfy(38,17): IsIndepImpliesMeasurableNat: Declaration has explicit `{:axiom}` attribute. 
+src/ProbabilisticProgramming/Independence.dfy(43,17): IsIndepImpliesIsIndepFunction: Declaration has explicit `{:axiom}` attribute. 
+src/ProbabilisticProgramming/Independence.dfy(48,17): CoinIsIndep: Declaration has explicit `{:axiom}` attribute. 
+src/ProbabilisticProgramming/Independence.dfy(52,17): ReturnIsIndep: Declaration has explicit `{:axiom}` attribute. 
+src/ProbabilisticProgramming/Independence.dfy(56,17): BindIsIndep: Declaration has explicit `{:axiom}` attribute. 
+src/ProbabilisticProgramming/Loops.dfy(312,17): EnsureWhileTerminates: Declaration has explicit `{:axiom}` attribute. 
+src/ProbabilisticProgramming/Loops.dfy(318,17): UntilProbabilityFraction: Declaration has explicit `{:axiom}` attribute. 
+src/ProbabilisticProgramming/Loops.dfy(350,4): EnsureUntilTerminatesAndForAll: Definition has `assume {:axiom}` statement in body. 
+src/ProbabilisticProgramming/Loops.dfy(373,4): WhileIsIndep: Definition has `assume {:axiom}` statement in body. 
 src/ProbabilisticProgramming/RandomSource.dfy(52,17): ProbIsProbabilityMeasure: Declaration has explicit `{:axiom}` attribute. 
 src/ProbabilisticProgramming/RandomSource.dfy(56,17): CoinHasProbOneHalf: Declaration has explicit `{:axiom}` attribute. 
 src/ProbabilisticProgramming/RandomSource.dfy(63,17): MeasureHeadDrop: Declaration has explicit `{:axiom}` attribute. 

--- a/audit.log
+++ b/audit.log
@@ -17,10 +17,10 @@ src/ProbabilisticProgramming/Independence.dfy(43,17): IsIndepImpliesIsIndepFunct
 src/ProbabilisticProgramming/Independence.dfy(48,17): CoinIsIndep: Declaration has explicit `{:axiom}` attribute. 
 src/ProbabilisticProgramming/Independence.dfy(52,17): ReturnIsIndep: Declaration has explicit `{:axiom}` attribute. 
 src/ProbabilisticProgramming/Independence.dfy(56,17): BindIsIndep: Declaration has explicit `{:axiom}` attribute. 
-src/ProbabilisticProgramming/Loops.dfy(312,17): EnsureWhileTerminates: Declaration has explicit `{:axiom}` attribute. 
-src/ProbabilisticProgramming/Loops.dfy(318,17): UntilProbabilityFraction: Declaration has explicit `{:axiom}` attribute. 
-src/ProbabilisticProgramming/Loops.dfy(350,4): EnsureUntilTerminatesAndForAll: Definition has `assume {:axiom}` statement in body. 
-src/ProbabilisticProgramming/Loops.dfy(373,4): WhileIsIndep: Definition has `assume {:axiom}` statement in body. 
+src/ProbabilisticProgramming/Loops.dfy(311,17): EnsureWhileTerminates: Declaration has explicit `{:axiom}` attribute. 
+src/ProbabilisticProgramming/Loops.dfy(317,17): UntilProbabilityFraction: Declaration has explicit `{:axiom}` attribute. 
+src/ProbabilisticProgramming/Loops.dfy(349,4): EnsureUntilTerminatesAndForAll: Definition has `assume {:axiom}` statement in body. 
+src/ProbabilisticProgramming/Loops.dfy(372,4): WhileIsIndep: Definition has `assume {:axiom}` statement in body. 
 src/ProbabilisticProgramming/RandomSource.dfy(52,17): ProbIsProbabilityMeasure: Declaration has explicit `{:axiom}` attribute. 
 src/ProbabilisticProgramming/RandomSource.dfy(56,17): CoinHasProbOneHalf: Declaration has explicit `{:axiom}` attribute. 
 src/ProbabilisticProgramming/RandomSource.dfy(63,17): MeasureHeadDrop: Declaration has explicit `{:axiom}` attribute. 

--- a/src/Distributions/Bernoulli/Correctness.dfy
+++ b/src/Distributions/Bernoulli/Correctness.dfy
@@ -43,19 +43,21 @@ module Bernoulli.Correctness {
     requires n != 0
     requires m <= n
     ensures
-      var e := iset s | Model.Sample(m, n)(s).value;
+      var e := iset s | Model.Sample(m, n)(s).Equals(true);
       && e in Rand.eventSpace
       && Rand.prob(e) == m as real / n as real
   {
     reveal Model.Sample();
-    var e := iset s | Model.Sample(m, n)(s).value;
+    var e := iset s | Model.Sample(m, n)(s).Equals(true);
+    var ltM: nat -> bool := x => x < m;
+    var ltM1: nat -> bool := x => x < m - 1;
 
     if m == 0 {
       assert e == iset{} by {
-        forall s ensures !Model.Sample(m, n)(s).value {
+        forall s ensures !Model.Sample(m, n)(s).Equals(true) {
           calc {
-            Model.Sample(m, n)(s).value;
-            Uniform.Model.Sample(n)(s).value < 0;
+            Model.Sample(m, n)(s).Equals(true);
+            Uniform.Model.Sample(n)(s).Satisfies(x => x < 0);
             false;
           }
         }
@@ -67,13 +69,13 @@ module Bernoulli.Correctness {
         assert Measures.IsPositive(Rand.eventSpace, Rand.prob);
       }
     } else {
-      var e1 := iset s | Uniform.Model.Sample(n)(s).value == m-1;
-      var e2 := (iset s {:trigger Uniform.Model.Sample(n)(s).value} | Model.Sample(m-1, n)(s).value);
+      var e1 := iset s | Uniform.Model.Sample(n)(s).Equals(m - 1);
+      var e2 := (iset s {:trigger Uniform.Model.Sample(n)(s).value} | Model.Sample(m-1, n)(s).Equals(true));
 
-      assert (iset s | Uniform.Model.Sample(n)(s).value < m-1) == e2 by {
-        assert (iset s | Uniform.Model.Sample(n)(s).value < m-1) == (iset s {:trigger Uniform.Model.Sample(n)(s).value} | Model.Sample(m-1, n)(s).value) by {
-          forall s ensures Uniform.Model.Sample(n)(s).value < m-1 <==> Model.Sample(m-1, n)(s).value {
-            assert Uniform.Model.Sample(n)(s).value < m-1 <==> Model.Sample(m-1, n)(s).value;
+      assert (iset s | Uniform.Model.Sample(n)(s).Satisfies(ltM1)) == e2 by {
+        assert (iset s | Uniform.Model.Sample(n)(s).Satisfies(ltM1)) == (iset s {:trigger Uniform.Model.Sample(n)(s).value} | Model.Sample(m-1, n)(s).Equals(true)) by {
+          forall s ensures Uniform.Model.Sample(n)(s).Satisfies(ltM1) <==> Model.Sample(m-1, n)(s).Equals(true) {
+            assert Uniform.Model.Sample(n)(s).Satisfies(ltM1) <==> Model.Sample(m-1, n)(s).Equals(true);
           }
         }
       }
@@ -81,9 +83,9 @@ module Bernoulli.Correctness {
       assert e == e1 + e2 by {
         calc {
           e;
-          iset s | Uniform.Model.Sample(n)(s).value < m;
-          iset s | Uniform.Model.Sample(n)(s).value == m-1 || Uniform.Model.Sample(n)(s).value < m-1;
-          (iset s | Uniform.Model.Sample(n)(s).value == m-1) + (iset s | Uniform.Model.Sample(n)(s).value < m-1);
+          iset s | Uniform.Model.Sample(n)(s).Satisfies(ltM);
+          iset s | Uniform.Model.Sample(n)(s).Equals(m-1) || Uniform.Model.Sample(n)(s).Satisfies(ltM1);
+          (iset s | Uniform.Model.Sample(n)(s).Equals(m-1)) + (iset s | Uniform.Model.Sample(n)(s).Satisfies(ltM1));
           e1 + e2;
         }
       }

--- a/src/Distributions/Bernoulli/Model.dfy
+++ b/src/Distributions/Bernoulli/Model.dfy
@@ -11,9 +11,8 @@ module Bernoulli.Model {
   opaque ghost function Sample(numer: nat, denom: nat): (f: Monad.Hurd<bool>)
     requires denom != 0
     requires numer <= denom
-    ensures forall s :: f(s).value == (Uniform.Model.Sample(denom)(s).value < numer)
-    ensures forall s :: f(s).rest == Uniform.Model.Sample(denom)(s).rest
   {
+    // TODO: this should use Map instead of Bind
     Monad.Bind(Uniform.Model.Sample(denom), (k: nat) => Monad.Return(k < numer))
   }
 

--- a/src/Distributions/BernoulliExpNeg/Correctness.dfy
+++ b/src/Distributions/BernoulliExpNeg/Correctness.dfy
@@ -12,7 +12,7 @@ module BernoulliExpNeg.Correctness {
 
   lemma {:axiom} Correctness(gamma: Rationals.Rational)
     requires 0 <= gamma.numer
-    ensures Rand.prob(iset s | Model.Sample(gamma)(s).value) == Exponential.Exp(-Rationals.ToReal(gamma))
+    ensures Rand.prob(iset s | Model.Sample(gamma)(s).Equals(true)) == Exponential.Exp(-Rationals.ToReal(gamma))
 
   lemma {:axiom} SampleIsIndep(gamma: Rationals.Rational)
     requires 0 <= gamma.numer

--- a/src/Distributions/BernoulliExpNeg/Model.dfy
+++ b/src/Distributions/BernoulliExpNeg/Model.dfy
@@ -111,13 +111,13 @@ module BernoulliExpNeg.Model {
     ensures GammaLe1Loop(gamma)(ak)(s) == Monad.Bind(GammaLe1LoopIter(gamma)(ak), GammaLe1Loop(gamma))(s)
   {
     GammaLe1LoopTerminatesAlmostSurely(gamma);
-      calc {
-        GammaLe1Loop(gamma)(ak)(s);
-        { reveal GammaLe1Loop(); }
-        Loops.While(GammaLe1LoopCondition, GammaLe1LoopIter(gamma), ak)(s);
-        { reveal GammaLe1Loop();
-          Loops.WhileUnroll(GammaLe1LoopCondition, GammaLe1LoopIter(gamma), ak, s); }
-        Monad.Bind(GammaLe1LoopIter(gamma)(ak), GammaLe1Loop(gamma))(s);
-      }
+    calc {
+      GammaLe1Loop(gamma)(ak)(s);
+      { reveal GammaLe1Loop(); }
+      Loops.While(GammaLe1LoopCondition, GammaLe1LoopIter(gamma), ak)(s);
+      { reveal GammaLe1Loop();
+        Loops.WhileUnroll(GammaLe1LoopCondition, GammaLe1LoopIter(gamma), ak, s); }
+      Monad.Bind(GammaLe1LoopIter(gamma)(ak), GammaLe1Loop(gamma))(s);
+    }
   }
 }

--- a/src/Distributions/BernoulliExpNeg/Model.dfy
+++ b/src/Distributions/BernoulliExpNeg/Model.dfy
@@ -111,16 +111,13 @@ module BernoulliExpNeg.Model {
     ensures GammaLe1Loop(gamma)(ak)(s) == Monad.Bind(GammaLe1LoopIter(gamma)(ak), GammaLe1Loop(gamma))(s)
   {
     GammaLe1LoopTerminatesAlmostSurely(gamma);
-    var Result(ak', s') := GammaLe1LoopIter(gamma)(ak)(s);
-    calc {
-      GammaLe1Loop(gamma)(ak)(s);
-      { reveal GammaLe1Loop(); }
-      Loops.While(GammaLe1LoopCondition, GammaLe1LoopIter(gamma), ak)(s);
-      { Loops.WhileUnroll(GammaLe1LoopCondition, GammaLe1LoopIter(gamma), ak, s); }
-      Loops.While(GammaLe1LoopCondition, GammaLe1LoopIter(gamma), ak')(s');
-      { reveal GammaLe1Loop(); }
-      GammaLe1Loop(gamma)(ak')(s');
-      Monad.Bind(GammaLe1LoopIter(gamma)(ak), GammaLe1Loop(gamma))(s);
-    }
+      calc {
+        GammaLe1Loop(gamma)(ak)(s);
+        { reveal GammaLe1Loop(); }
+        Loops.While(GammaLe1LoopCondition, GammaLe1LoopIter(gamma), ak)(s);
+        { reveal GammaLe1Loop();
+          Loops.WhileUnroll(GammaLe1LoopCondition, GammaLe1LoopIter(gamma), ak, s); }
+        Monad.Bind(GammaLe1LoopIter(gamma)(ak), GammaLe1Loop(gamma))(s);
+      }
   }
 }

--- a/src/Distributions/Uniform/Correctness.dfy
+++ b/src/Distributions/Uniform/Correctness.dfy
@@ -21,7 +21,7 @@ module Uniform.Correctness {
   ghost function SampleEquals(n: nat, i: nat): iset<Rand.Bitstream>
     requires 0 <= i < n
   {
-    iset s | Model.Sample(n)(s).value == i
+    iset s | Model.Sample(n)(s).Equals(i)
   }
 
   /*******
@@ -137,7 +137,7 @@ module Uniform.Correctness {
   lemma UniformFullIntervalCorrectness(a: int, b: int, i: int)
     requires a <= i < b
     ensures
-      var e := iset s | Model.IntervalSample(a, b)(s).value == i;
+      var e := iset s | Model.IntervalSample(a, b)(s).Equals(i);
       && e in Rand.eventSpace
       && Rand.prob(e) == (1.0 / ((b-a) as real))
   {
@@ -147,10 +147,10 @@ module Uniform.Correctness {
     var e' := SampleEquals(b - a, i - a);
     assert e' in Rand.eventSpace by { UniformFullCorrectness(b - a, i - a); }
     assert Rand.prob(e') == (1.0 / ((b-a) as real)) by { UniformFullCorrectness(b - a, i - a); }
-    var e := iset s | Model.IntervalSample(a, b)(s).value == i;
+    var e := iset s | Model.IntervalSample(a, b)(s).Equals(i);
     assert e == e' by {
-      forall s ensures Model.IntervalSample(a, b)(s).value == i <==> Model.Sample(b-a)(s).value == i - a {
-        assert Model.IntervalSample(a, b)(s).value == a + Model.Sample(b - a)(s).value;
+      forall s ensures Model.IntervalSample(a, b)(s).Equals(i) <==> Model.Sample(b-a)(s).Equals(i - a) {
+        assert Model.IntervalSample(a, b)(s) == Model.Sample(b - a)(s).Map(x => a + x);
       }
     }
   }

--- a/src/Distributions/Uniform/Model.dfy
+++ b/src/Distributions/Uniform/Model.dfy
@@ -51,14 +51,15 @@ module Uniform.Model {
     }
     var e := iset s | Loops.ProposalIsAccepted(Proposal(n), Accept(n))(s);
     assert e in Rand.eventSpace by {
-      assert e == Measures.PreImage(s => UniformPowerOfTwo.Model.Sample(2 * n)(s).value, (iset m: nat | m < n));
-      assert Measures.PreImage(s => UniformPowerOfTwo.Model.Sample(2 * n)(s).value, (iset m: nat | m < n)) in Rand.eventSpace by {
+      assert e == Measures.PreImage(UniformPowerOfTwo.Model.Sample(2 * n), (iset r: Monad.Result<nat> | r.Result? && r.value < n));
+      assert Measures.PreImage(UniformPowerOfTwo.Model.Sample(2 * n), (iset r: Monad.Result<nat> | r.Result? && r.value < n)) in Rand.eventSpace by {
         assert Independence.IsIndep(UniformPowerOfTwo.Model.Sample(2 * n)) by {
           UniformPowerOfTwo.Correctness.SampleIsIndep(2 * n);
         }
-        assert Measures.IsMeasurable(Rand.eventSpace, Measures.natEventSpace, s => UniformPowerOfTwo.Model.Sample(2 * n)(s).value) by {
-          Independence.IsIndepImpliesValueMeasurableNat(UniformPowerOfTwo.Model.Sample(2 * n));
+        assert Measures.IsMeasurable(Rand.eventSpace, Monad.ResultEventSpace(Measures.natEventSpace), UniformPowerOfTwo.Model.Sample(2 * n)) by {
+          Independence.IsIndepImpliesMeasurableNat(UniformPowerOfTwo.Model.Sample(2 * n));
         }
+        assert (iset r: Monad.Result<nat> | r.Result? && r.value < n) in Monad.ResultEventSpace(Measures.natEventSpace);
       }
     }
     assert Quantifier.WithPosProb(Loops.ProposalIsAccepted(Proposal(n), Accept(n))) by {

--- a/src/Distributions/Uniform/Model.dfy
+++ b/src/Distributions/Uniform/Model.dfy
@@ -51,15 +51,19 @@ module Uniform.Model {
     }
     var e := iset s | Loops.ProposalIsAccepted(Proposal(n), Accept(n))(s);
     assert e in Rand.eventSpace by {
-      assert e == Measures.PreImage(UniformPowerOfTwo.Model.Sample(2 * n), (iset r: Monad.Result<nat> | r.Result? && r.value < n));
-      assert Measures.PreImage(UniformPowerOfTwo.Model.Sample(2 * n), (iset r: Monad.Result<nat> | r.Result? && r.value < n)) in Rand.eventSpace by {
+      var ltN := iset m: nat | m < n;
+      var resultsLtN := Monad.ResultsWithValueIn(ltN);
+      assert e == Measures.PreImage(UniformPowerOfTwo.Model.Sample(2 * n), resultsLtN);
+      assert Measures.PreImage(UniformPowerOfTwo.Model.Sample(2 * n), resultsLtN) in Rand.eventSpace by {
         assert Independence.IsIndep(UniformPowerOfTwo.Model.Sample(2 * n)) by {
           UniformPowerOfTwo.Correctness.SampleIsIndep(2 * n);
         }
-        assert Measures.IsMeasurable(Rand.eventSpace, Monad.ResultEventSpace(Measures.natEventSpace), UniformPowerOfTwo.Model.Sample(2 * n)) by {
+        assert Measures.IsMeasurable(Rand.eventSpace, Monad.natResultEventSpace, UniformPowerOfTwo.Model.Sample(2 * n)) by {
           Independence.IsIndepImpliesMeasurableNat(UniformPowerOfTwo.Model.Sample(2 * n));
         }
-        assert (iset r: Monad.Result<nat> | r.Result? && r.value < n) in Monad.ResultEventSpace(Measures.natEventSpace);
+        assert resultsLtN in Monad.natResultEventSpace by {
+          Monad.LiftInEventSpaceToResultEventSpace(ltN, Measures.natEventSpace);
+        }
       }
     }
     assert Quantifier.WithPosProb(Loops.ProposalIsAccepted(Proposal(n), Accept(n))) by {

--- a/src/Distributions/Uniform/Model.dfy
+++ b/src/Distributions/Uniform/Model.dfy
@@ -36,9 +36,7 @@ module Uniform.Model {
   ghost function IntervalSample(a: int, b: int): (f: Monad.Hurd<int>)
     requires a < b
   {
-    (s: Rand.Bitstream) =>
-      var Result(x, s') := Sample(b - a)(s);
-      Monad.Result(a + x, s')
+    Monad.Map(Sample(b - a), x => a + x)
   }
 
   lemma SampleTerminates(n: nat)

--- a/src/Distributions/UniformPowerOfTwo/Correctness.dfy
+++ b/src/Distributions/UniformPowerOfTwo/Correctness.dfy
@@ -226,11 +226,11 @@ module UniformPowerOfTwo.Correctness {
               calc {
                 f(s) in e;
               <==> { assert f(s) == Model.Sample(n)(s).rest; }
-                Model.Sample(n)(s).RestIn(e);
+                Model.Sample(n)(s).rest in e;
               <==> { SampleTailDecompose(n, s); }
                 Rand.Tail(Model.Sample(n / 2)(s).rest) in e;
               <==>
-                Model.Sample(n / 2)(s).RestIn(e');
+                Model.Sample(n / 2)(s).rest in e';
               <==> { assert Model.Sample(n / 2)(s).rest == g(s); }
                 g(s) in e';
               }
@@ -319,8 +319,8 @@ module UniformPowerOfTwo.Correctness {
     var E: iset<Rand.Bitstream> := (iset s | m % 2 as nat == Helper.boolToNat(Monad.Coin(s).value));
     var f := (s: Rand.Bitstream) => Model.Sample(n / 2)(s).rest;
 
-    var e1 := (iset s | Model.Sample(n / 2)(s).RestIn(E));
-    var e2 := (iset s | Model.Sample(n / 2)(s).In(A));
+    var e1 := (iset s | Model.Sample(n / 2)(s).rest in E);
+    var e2 := (iset s | Model.Sample(n / 2)(s).value in A);
     var e3 := (iset s | 2*aOf(s) + Helper.boolToNat(bOf(s)) == m);
 
     assert SplitEvent: e3 == e1 * e2 by {
@@ -339,7 +339,7 @@ module UniformPowerOfTwo.Correctness {
     }
 
     assert Eq2: (iset s | aOf(s) == m / 2) == e2 by {
-      forall s ensures aOf(s) == m / 2 <==> Model.Sample(n / 2)(s).In(A) {
+      forall s ensures aOf(s) == m / 2 <==> Model.Sample(n / 2)(s).value in A {
       }
     }
 
@@ -350,7 +350,7 @@ module UniformPowerOfTwo.Correctness {
     }
 
     assert Eq4: e1 == Measures.PreImage(f, E) by {
-      forall s ensures Model.Sample(n / 2)(s).RestIn(E) <==> f(s) in E {
+      forall s ensures Model.Sample(n / 2)(s).rest in E <==> f(s) in E {
       }
     }
 

--- a/src/Distributions/UniformPowerOfTwo/Correctness.dfy
+++ b/src/Distributions/UniformPowerOfTwo/Correctness.dfy
@@ -50,9 +50,9 @@ module UniformPowerOfTwo.Correctness {
       assert iset{m} in Measures.natEventSpace;
       var preimage := Measures.PreImage((s: Rand.Bitstream) => Model.Sample(n)(s).value, iset{m});
       assert preimage in Rand.eventSpace by {
-        assert Measures.IsMeasurable(Rand.eventSpace, Measures.natEventSpace, s => Model.Sample(n)(s).value) by {
+        assert Measures.IsMeasurable(Rand.eventSpace, Monad.natResultEventSpace, Model.Sample(n)) by {
           SampleIsIndep(n);
-          Independence.IsIndepImpliesValueMeasurableNat(Model.Sample(n));
+          Independence.IsIndepImpliesMeasurableNat(Model.Sample(n));
         }
       }
       assert e == preimage;
@@ -187,9 +187,9 @@ module UniformPowerOfTwo.Correctness {
     ensures Measures.IsMeasurePreserving(Rand.eventSpace, Rand.prob, Rand.eventSpace, Rand.prob, Sample1(n))
   {
     var f := Sample1(n);
-    assert Measures.IsMeasurable(Rand.eventSpace, Rand.eventSpace, f) by {
+    assert Measures.IsMeasurable(Rand.eventSpace, Monad.natResultEventSpace, f) by {
       SampleIsIndep(n);
-      Independence.IsIndepImpliesRestMeasurable(Model.Sample(n));
+      Independence.IsIndepImpliesMeasurableNat(Model.Sample(n));
       assert Independence.IsIndep(Model.Sample(n));
     }
     if n == 1 {

--- a/src/Distributions/UniformPowerOfTwo/Correctness.dfy
+++ b/src/Distributions/UniformPowerOfTwo/Correctness.dfy
@@ -216,11 +216,11 @@ module UniformPowerOfTwo.Correctness {
               calc {
                 f(s) in e;
               <==> { assert f(s) == Model.Sample(n)(s).rest; }
-                Model.Sample(n)(s).rest in e;
+                Model.Sample(n)(s).RestIn(e);
               <==> { SampleTailDecompose(n, s); }
                 Rand.Tail(Model.Sample(n / 2)(s).rest) in e;
               <==>
-                Model.Sample(n / 2)(s).rest in e';
+                Model.Sample(n / 2)(s).RestIn(e');
               <==> { assert Model.Sample(n / 2)(s).rest == g(s); }
                 g(s) in e';
               }
@@ -309,8 +309,8 @@ module UniformPowerOfTwo.Correctness {
     var E: iset<Rand.Bitstream> := (iset s | m % 2 as nat == Helper.boolToNat(Monad.Coin(s).value));
     var f := (s: Rand.Bitstream) => Model.Sample(n / 2)(s).rest;
 
-    var e1 := (iset s | Model.Sample(n / 2)(s).rest in E);
-    var e2 := (iset s | Model.Sample(n / 2)(s).value in A);
+    var e1 := (iset s | Model.Sample(n / 2)(s).RestIn(E));
+    var e2 := (iset s | Model.Sample(n / 2)(s).In(A));
     var e3 := (iset s | 2*aOf(s) + Helper.boolToNat(bOf(s)) == m);
 
     assert SplitEvent: e3 == e1 * e2 by {
@@ -329,7 +329,7 @@ module UniformPowerOfTwo.Correctness {
     }
 
     assert Eq2: (iset s | aOf(s) == m / 2) == e2 by {
-      forall s ensures aOf(s) == m / 2 <==> Model.Sample(n / 2)(s).value in A {
+      forall s ensures aOf(s) == m / 2 <==> Model.Sample(n / 2)(s).In(A) {
       }
     }
 
@@ -340,7 +340,7 @@ module UniformPowerOfTwo.Correctness {
     }
 
     assert Eq4: e1 == Measures.PreImage(f, E) by {
-      forall s ensures Model.Sample(n / 2)(s).rest in E <==> f(s) in E {
+      forall s ensures Model.Sample(n / 2)(s).RestIn(E) <==> f(s) in E {
       }
     }
 

--- a/src/Distributions/UniformPowerOfTwo/Correctness.dfy
+++ b/src/Distributions/UniformPowerOfTwo/Correctness.dfy
@@ -319,8 +319,8 @@ module UniformPowerOfTwo.Correctness {
     var E: iset<Rand.Bitstream> := (iset s | m % 2 as nat == Helper.boolToNat(Monad.Coin(s).value));
     var f := (s: Rand.Bitstream) => Model.Sample(n / 2)(s).rest;
 
-    var e1 := (iset s | Model.Sample(n / 2)(s).rest in E);
-    var e2 := (iset s | Model.Sample(n / 2)(s).value in A);
+    var e1 := (iset s | Model.Sample(n / 2)(s).RestIn(E));
+    var e2 := (iset s | Model.Sample(n / 2)(s).In(A));
     var e3 := (iset s | 2*aOf(s) + Helper.boolToNat(bOf(s)) == m);
 
     assert SplitEvent: e3 == e1 * e2 by {

--- a/src/Distributions/UniformPowerOfTwo/Model.dfy
+++ b/src/Distributions/UniformPowerOfTwo/Model.dfy
@@ -23,6 +23,7 @@ module UniformPowerOfTwo.Model {
   // The return value u is uniformly distributed between 0 <= u < 2^k where 2^k <= n < 2^(k + 1).
   opaque function Sample(n: nat): (h: Monad.Hurd<nat>)
     requires n >= 1
+    ensures forall s :: Sample(n)(s).Result? // always terminates, not just almost surely
   {
     if n == 1 then
       Monad.Return(0)

--- a/src/Math/Measures.dfy
+++ b/src/Math/Measures.dfy
@@ -122,6 +122,17 @@ module Measures {
     ensures PreImage(f, e) == PreImage(f', e')
   {}
 
+  lemma SampleSpaceInEventSpace<T>(sampleSpace: iset<T>, eventSpace: iset<iset<T>>)
+    requires IsSigmaAlgebra(eventSpace, sampleSpace)
+    ensures sampleSpace in eventSpace
+  {
+    var empty := iset{};
+    assert empty in eventSpace;
+    var compl := sampleSpace - empty;
+    assert compl == sampleSpace;
+    assert compl in eventSpace;
+  }
+
   // Equation (2.18)
   lemma PosCountAddImpliesAdd<T(!new)>(eventSpace: iset<iset<T>>, sampleSpace: iset<T>, Prob: iset<T> -> real)
     requires IsSigmaAlgebra(eventSpace, sampleSpace)

--- a/src/Math/Measures.dfy
+++ b/src/Math/Measures.dfy
@@ -26,14 +26,22 @@ module Measures {
     f(i) + CountableSum(f, i+1)
   }
 
-  ghost const boolSampleSpace: iset<bool> := iset _: bool
+  ghost function Powerset<A(!new)>(): iset<A> {
+    iset _: A
+  }
 
-  ghost const boolEventSpace: iset<iset<bool>> := iset _: iset<bool>
+  ghost function DiscreteSigmaAlgebra<A(!new)>(): iset<iset<A>> {
+    iset _: iset<A>
+  }
 
-  ghost const natSampleSpace: iset<nat> := iset _: nat
+  ghost const boolSampleSpace: iset<bool> := Powerset<bool>()
+
+  ghost const boolEventSpace: iset<iset<bool>> := DiscreteSigmaAlgebra<bool>()
+
+  ghost const natSampleSpace: iset<nat> := Powerset<nat>()
 
   // The sigma algebra on the natural numbers is just the power set
-  ghost const natEventSpace: iset<iset<nat>> := iset _: iset<nat>
+  ghost const natEventSpace: iset<iset<nat>> := DiscreteSigmaAlgebra<nat>()
 
   // Definition 5
   ghost predicate IsPositive<T(!new)>(eventSpace: iset<iset<T>>, Prob: iset<T> -> real) {

--- a/src/ProbabilisticProgramming/Independence.dfy
+++ b/src/ProbabilisticProgramming/Independence.dfy
@@ -14,8 +14,8 @@ module Independence {
 
   // Definition 33
   ghost predicate IsIndepFunctionCondition<A(!new)>(f: Monad.Hurd<A>, A: iset<A>, E: iset<Rand.Bitstream>) {
-    var e1 := iset s | f(s).rest in E;
-    var e2 := iset s | f(s).value in A;
+    var e1 := iset s | f(s).RestIn(E);
+    var e2 := iset s | f(s).In(A);
     Measures.AreIndepEvents(Rand.eventSpace, Rand.prob, e1, e2)
   }
 

--- a/src/ProbabilisticProgramming/Independence.dfy
+++ b/src/ProbabilisticProgramming/Independence.dfy
@@ -19,30 +19,27 @@ module Independence {
     Measures.AreIndepEvents(Rand.eventSpace, Rand.prob, e1, e2)
   }
 
-  // Definition 33
+  // Definition 33: (weak) independence
   ghost predicate IsIndepFunction<A(!new)>(f: Monad.Hurd<A>) {
     forall A: iset<A>, E: iset<Rand.Bitstream> | E in Rand.eventSpace :: IsIndepFunctionCondition(f, A, E)
   }
 
-  // Definition 35
+  // Definition 35: (strong) independence
   ghost predicate {:axiom} IsIndep<A(!new)>(f: Monad.Hurd<A>)
 
   /*******
    Lemmas
   *******/
 
-  lemma {:axiom} IsIndepImpliesValueMeasurableBool(f: Monad.Hurd<bool>)
+  lemma {:axiom} IsIndepImpliesMeasurableBool(f: Monad.Hurd<bool>)
     requires IsIndep(f)
-    ensures Measures.IsMeasurable(Rand.eventSpace, Measures.boolEventSpace, s => f(s).value)
+    ensures Measures.IsMeasurable(Rand.eventSpace, Monad.boolResultEventSpace, f)
 
-  lemma {:axiom} IsIndepImpliesValueMeasurableNat(f: Monad.Hurd<nat>)
+  lemma {:axiom} IsIndepImpliesMeasurableNat(f: Monad.Hurd<nat>)
     requires IsIndep(f)
-    ensures Measures.IsMeasurable(Rand.eventSpace, Measures.natEventSpace, s => f(s).value)
+    ensures Measures.IsMeasurable(Rand.eventSpace, Monad.natResultEventSpace, f)
 
-  lemma {:axiom} IsIndepImpliesRestMeasurable<A(!new)>(f: Monad.Hurd<A>)
-    requires IsIndep(f)
-    ensures Measures.IsMeasurable(Rand.eventSpace, Rand.eventSpace, s => f(s).rest)
-
+  // Equation (3.14)
   lemma {:axiom} IsIndepImpliesIsIndepFunction<A(!new)>(f: Monad.Hurd<A>)
     requires IsIndep(f)
     ensures IsIndepFunction(f)

--- a/src/ProbabilisticProgramming/Loops.dfy
+++ b/src/ProbabilisticProgramming/Loops.dfy
@@ -39,7 +39,7 @@ module Loops {
   // Definition of while loops.
   // This definition is opaque because the details are not very useful.
   // For proofs, use the lemma `WhileUnroll`.
-  // Equation (3.25)
+  // Equation (3.25), but modified to use `Monad.Diverging` instead of HOL's `arb` in case of nontermination
   // TODO: While(condition, body)(init) would be cleaner
   opaque ghost function While<A>(condition: A -> bool, body: A -> Monad.Hurd<A>, init: A): (f: Monad.Hurd<A>)
     ensures forall s: Rand.Bitstream :: !condition(init) ==> f(s) == Monad.Return(init)(s)
@@ -185,7 +185,6 @@ module Loops {
     if WhileCutTerminates(condition, body, init', s') {
       var fuel: nat :| WhileCutTerminatesWithFuel(condition, body, init', s')(fuel);
       WhileCutTerminatesWithFuelUnroll(condition, body, init, s, init', s', fuel);
-
     }
   }
 

--- a/src/ProbabilisticProgramming/Loops.dfy
+++ b/src/ProbabilisticProgramming/Loops.dfy
@@ -40,6 +40,7 @@ module Loops {
   // This definition is opaque because the details are not very useful.
   // For proofs, use the lemma `WhileUnroll`.
   // Equation (3.25)
+  // TODO: While(condition, body)(init) would be cleaner
   opaque ghost function While<A>(condition: A -> bool, body: A -> Monad.Hurd<A>, init: A): (f: Monad.Hurd<A>)
     ensures forall s: Rand.Bitstream :: !condition(init) ==> f(s) == Monad.Return(init)(s)
   {

--- a/src/ProbabilisticProgramming/Loops.dfy
+++ b/src/ProbabilisticProgramming/Loops.dfy
@@ -44,13 +44,14 @@ module Loops {
   opaque ghost function While<A>(condition: A -> bool, body: A -> Monad.Hurd<A>, init: A): (f: Monad.Hurd<A>)
     ensures forall s: Rand.Bitstream :: !condition(init) ==> f(s) == Monad.Return(init)(s)
   {
-    var f := (s: Rand.Bitstream) =>
-      if WhileCutTerminates(condition, body, init, s)
-      then
-        var fuel := LeastFuel(condition, body, init, s);
-        WhileCut(condition, body, init, fuel)(s)
-      else
-        Monad.Diverging;
+    var f :=
+      (s: Rand.Bitstream) =>
+        if WhileCutTerminates(condition, body, init, s)
+        then
+          var fuel := LeastFuel(condition, body, init, s);
+          WhileCut(condition, body, init, fuel)(s)
+        else
+          Monad.Diverging;
     assert forall s: Rand.Bitstream :: !condition(init) ==> f(s) == Monad.Return(init)(s) by {
       forall s: Rand.Bitstream ensures !condition(init) ==> f(s) == Monad.Return(init)(s) {
         if !condition(init) {

--- a/src/ProbabilisticProgramming/Loops.dfy
+++ b/src/ProbabilisticProgramming/Loops.dfy
@@ -26,7 +26,7 @@ module Loops {
   }
 
   ghost function WhileCutTerminatesWithFuel<A>(condition: A -> bool, body: A -> Monad.Hurd<A>, init: A, s: Rand.Bitstream): nat -> bool {
-    (fuel: nat) => !condition(WhileCut(condition, body, init, fuel)(s).value)
+    (fuel: nat) => !WhileCut(condition, body, init, fuel)(s).Satisfies(condition)
   }
 
   // Definition 39 / True iff Prob(iset s | While(condition, body, a)(s) terminates) == 1
@@ -43,14 +43,21 @@ module Loops {
   opaque ghost function While<A>(condition: A -> bool, body: A -> Monad.Hurd<A>, init: A): (f: Monad.Hurd<A>)
     ensures forall s: Rand.Bitstream :: !condition(init) ==> f(s) == Monad.Return(init)(s)
   {
-    (s: Rand.Bitstream) =>
+    var f := (s: Rand.Bitstream) =>
       if WhileCutTerminates(condition, body, init, s)
       then
         var fuel := LeastFuel(condition, body, init, s);
         WhileCut(condition, body, init, fuel)(s)
       else
-        // In HOL, Hurd returns `arb` here, which is not possible in Dafny.
-        Monad.Result(init, s)
+        Monad.Diverging;
+    assert forall s: Rand.Bitstream :: !condition(init) ==> f(s) == Monad.Return(init)(s) by {
+      forall s: Rand.Bitstream ensures !condition(init) ==> f(s) == Monad.Return(init)(s) {
+        if !condition(init) {
+          assert WhileCutTerminatesWithFuel(condition, body, init, s)(0);
+        }
+      }
+    }
+    f
   }
 
   ghost function LeastFuel<A>(condition: A -> bool, body: A -> Monad.Hurd<A>, init: A, s: Rand.Bitstream): (fuel: nat)
@@ -89,7 +96,7 @@ module Loops {
     ensures
       var reject := (a: A) => !accept(a);
       var body := (a: A) => proposal;
-      forall s :: f(s) == While(reject, body, proposal(s).value)(proposal(s).rest)
+      forall s :: f(s) == proposal(s).Bind(init => While(reject, body, init))
   {
     var reject := (a: A) => !accept(a);
     var body := (a: A) => proposal;
@@ -98,35 +105,34 @@ module Loops {
 
   function WhileLoopExitsAfterOneIteration<A(!new)>(body: A -> Monad.Hurd<A>, condition: A -> bool, init: A): (Rand.Bitstream -> bool) {
     (s: Rand.Bitstream) =>
-      !condition(body(init)(s).value)
+      body(init)(s).Satisfies(v => !condition(v))
   }
 
   function ProposalIsAccepted<A(!new)>(proposal: Monad.Hurd<A>, accept: A -> bool): (Rand.Bitstream -> bool) {
     (s: Rand.Bitstream) =>
-      accept(proposal(s).value)
+      proposal(s).Satisfies(accept)
   }
 
   ghost function UntilLoopResultIsAccepted<A>(proposal: Monad.Hurd<A>, accept: A -> bool): (Rand.Bitstream -> bool)
     requires UntilTerminatesAlmostSurely(proposal, accept)
   {
-    (s: Rand.Bitstream) =>
-      accept(Until(proposal, accept)(s).value)
+    (s: Rand.Bitstream) => Until(proposal, accept)(s).Satisfies(accept)
   }
 
   ghost function UntilLoopResultHasProperty<A>(proposal: Monad.Hurd<A>, accept: A -> bool, property: A -> bool): iset<Rand.Bitstream>
     requires UntilTerminatesAlmostSurely(proposal, accept)
   {
-    iset s | property(Until(proposal, accept)(s).value)
+    iset s | Until(proposal, accept)(s).Satisfies(property)
   }
 
   ghost function ProposalIsAcceptedAndHasProperty<A>(proposal: Monad.Hurd<A>, accept: A -> bool, property: A -> bool): iset<Rand.Bitstream>
   {
-    iset s | property(proposal(s).value) && accept(proposal(s).value)
+    iset s | proposal(s).Satisfies(property) && proposal(s).Satisfies(accept)
   }
 
   ghost function ProposalAcceptedEvent<A>(proposal: Monad.Hurd<A>, accept: A -> bool): iset<Rand.Bitstream>
   {
-    iset s | accept(proposal(s).value)
+    iset s | proposal(s).Satisfies(accept)
   }
 
 
@@ -203,13 +209,15 @@ module Loops {
     ensures loop == unrolled
   {
     if condition(init) {
-      var Result(init', s') := body(init)(s);
-      calc {
-        loop;
-        { WhileUnrollIfConditionSatisfied(condition, body, init, s, init', s', loop, unrolled); }
-        While(condition, body, init')(s');
-        unrolled;
-      }
+      match body(init)(s)
+      case Diverging => assume false;
+      case Result(init', s') =>
+        calc {
+          loop;
+          { WhileUnrollIfConditionSatisfied(condition, body, init, s, init', s', loop, unrolled); }
+          While(condition, body, init')(s');
+          unrolled;
+        }
     } else {
       calc {
         loop;
@@ -241,12 +249,12 @@ module Loops {
 
   lemma EnsureUntilTerminates<A(!new)>(proposal: Monad.Hurd<A>, accept: A -> bool)
     requires Independence.IsIndep(proposal)
-    requires Quantifier.WithPosProb((s: Rand.Bitstream) => accept(proposal(s).value))
+    requires Quantifier.WithPosProb((s: Rand.Bitstream) => proposal(s).Satisfies(accept))
     ensures UntilTerminatesAlmostSurely(proposal, accept)
   {
     var reject := (a: A) => !accept(a);
     var body := (a: A) => proposal;
-    var proposalIsAccepted := (s: Rand.Bitstream) => accept(proposal(s).value);
+    var proposalIsAccepted := (s: Rand.Bitstream) => proposal(s).Satisfies(accept);
     assert UntilTerminatesAlmostSurely(proposal, accept) by {
       forall a: A ensures Independence.IsIndep(body(a)) {
         assert body(a) == proposal;
@@ -287,8 +295,9 @@ module Loops {
   {
     var reject := (a: A) => !accept(a);
     var body := (a: A) => proposal;
-    var Result(init, s') := proposal(s);
-    WhileUnroll(reject, body, init, s');
+    match proposal(s)
+    case Diverging =>
+    case Result(init, s') => WhileUnroll(reject, body, init, s');
   }
 
   // Equation (3.40)

--- a/src/ProbabilisticProgramming/Monad.dfy
+++ b/src/ProbabilisticProgramming/Monad.dfy
@@ -18,8 +18,8 @@ module Monad {
   // The result of a probabilistic computation on a bitstream.
   // It either consists of the computed value and the (unconsumed) rest of the bitstream or indicates nontermination.
   datatype Result<A> =
-  | Result(value: A, rest: Rand.Bitstream)
-  | Diverging
+    | Result(value: A, rest: Rand.Bitstream)
+    | Diverging
   {
     function Map<B>(f: A -> B): Result<B> {
       match this

--- a/src/ProbabilisticProgramming/Monad.dfy
+++ b/src/ProbabilisticProgramming/Monad.dfy
@@ -144,7 +144,9 @@ module Monad {
     ensures ResultsWithValueIn(event) in ResultEventSpace(eventSpace)
   {
     var results := ResultsWithValueIn(event);
-    Rand.ProbIsProbabilityMeasure();
+    assert Measures.IsSigmaAlgebra(Rand.eventSpace, Rand.sampleSpace) by {
+      Rand.ProbIsProbabilityMeasure();
+    }
     assert Rand.sampleSpace in Rand.eventSpace by {
       Measures.SampleSpaceInEventSpace(Rand.sampleSpace, Rand.eventSpace);
     }
@@ -155,10 +157,7 @@ module Monad {
       }
     }
     assert Rests(results) in Rand.eventSpace by {
-      if event == iset{} {
-        assert Rests(results) == iset{};
-      } else {
-        var v :| v in event;
+      if v :| v in event {
         assert Rests(results) == Rand.sampleSpace by {
           forall s: Rand.Bitstream ensures s in Rests(results) <==> s in Rand.sampleSpace {
             calc {
@@ -168,6 +167,8 @@ module Monad {
             }
           }
         }
+      } else {
+        assert Rests(results) == iset{};
       }
     }
   }
@@ -179,20 +180,21 @@ module Monad {
     ensures ResultsWithRestIn(rests) in ResultEventSpace(eventSpace)
   {
     var results := ResultsWithRestIn(rests);
-    Rand.ProbIsProbabilityMeasure();
+    assert Measures.IsSigmaAlgebra(Rand.eventSpace, Rand.sampleSpace) by {
+      Rand.ProbIsProbabilityMeasure();
+    }
     assert Rand.sampleSpace in Rand.eventSpace by {
       Measures.SampleSpaceInEventSpace(Rand.sampleSpace, Rand.eventSpace);
     }
     assert Values(results) in eventSpace by {
-      if rests == iset{} {
-        assert Values(results) == iset{};
-      } else {
-        var rest :| rest in rests;
+      if rest :| rest in rests {
         assert Values(results) == Measures.Powerset<A>() by {
           forall v: A ensures v in Values(results) {
             assert Result(v, rest) in results;
           }
         }
+      } else {
+        assert Values(results) == iset{};
       }
     }
     assert Rests(results) in Rand.eventSpace by {

--- a/src/ProbabilisticProgramming/Monad.dfy
+++ b/src/ProbabilisticProgramming/Monad.dfy
@@ -17,6 +17,7 @@ module Monad {
 
   // The result of a probabilistic computation on a bitstream.
   // It either consists of the computed value and the (unconsumed) rest of the bitstream or indicates nontermination.
+  // It differs from Hurd's definition in that the result can be nontermination, which Hurd does not model explicitly.
   datatype Result<A> =
     | Result(value: A, rest: Rand.Bitstream)
     | Diverging


### PR DESCRIPTION
This PR changes the type of `Monad.Result<A>` from `Result(value: A, rest: Rand.Bitstream)` to `Diverging | Result(value: A, rest: Rand.Bitstream)`. In order to make it easier to work with, it also adds a few combinators for `Monad.Result` in order to avoid pattern matching everywhere.

The main benefit of this is that `While` loops can be properly defined without `assume false` and we can prove Hurd's theorem 38 (while loop unrolling) in Dafny. Another benefit is that we can reason about nontermination probabilities in Dafny via `Rand.prob(iset s | Sample(s).Diverging?)` for a probabilistic computation `Sample: Hurd<A>`.

For reasoning about the measurability of results, I also introduced some infrastructure to lift measure spaces on `A` to `Result<A>`, see `Monad.ResultEventSpace`, `Monad.LiftInEventSpaceToResultEventSpace`, and `Monad.LiftRestInEventSpaceToResultEventSpace`. In fact, the measurability proofs required the most modifications as a result of the change.

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).
