### PR TITLE
Finish* the correctness proof of BernoulliExpNeg

### DIFF
--- a/audit.log
+++ b/audit.log
@@ -1,14 +1,15 @@
 src/Distributions/Bernoulli/Correctness.dfy(59,17): BernoulliCorrectnessCaseFalse: Declaration has explicit `{:axiom}` attribute. 
-src/Distributions/BernoulliExpNeg/Correctness.dfy(134,17): CorrectnessLe1: Declaration has explicit `{:axiom}` attribute. 
-src/Distributions/BernoulliExpNeg/Correctness.dfy(170,17): SampleLe1IsIndep: Declaration has explicit `{:axiom}` attribute. 
-src/Distributions/BernoulliExpNeg/Correctness.dfy(308,6): Le1LoopCutDecomposeProb: Definition has `assume {:axiom}` statement in body. 
-src/Distributions/BernoulliExpNeg/Correctness.dfy(309,6): Le1LoopCutDecomposeProb: Definition has `assume {:axiom}` statement in body. 
-src/Distributions/BernoulliExpNeg/Correctness.dfy(316,6): Le1LoopCutDecomposeProb: Definition has `assume {:axiom}` statement in body. 
-src/Distributions/BernoulliExpNeg/Correctness.dfy(317,6): Le1LoopCutDecomposeProb: Definition has `assume {:axiom}` statement in body. 
-src/Distributions/BernoulliExpNeg/Correctness.dfy(321,6): Le1LoopCutDecomposeProb: Definition has `assume {:axiom}` statement in body. 
-src/Distributions/BernoulliExpNeg/Correctness.dfy(322,6): Le1LoopCutDecomposeProb: Definition has `assume {:axiom}` statement in body. 
-src/Distributions/BernoulliExpNeg/Correctness.dfy(512,8): Le1LoopCorrectnessEq: Definition has `assume {:axiom}` statement in body. 
-src/Distributions/BernoulliExpNeg/Correctness.dfy(513,8): Le1LoopCorrectnessEq: Definition has `assume {:axiom}` statement in body. 
+src/Distributions/BernoulliExpNeg/Correctness.dfy(226,6): CorrectnessLe1: Definition has `assume {:axiom}` statement in body. 
+src/Distributions/BernoulliExpNeg/Correctness.dfy(249,17): SampleLe1IsIndep: Declaration has explicit `{:axiom}` attribute. 
+src/Distributions/BernoulliExpNeg/Correctness.dfy(301,17): Le1SeriesConvergesToExpNeg: Declaration has explicit `{:axiom}` attribute. 
+src/Distributions/BernoulliExpNeg/Correctness.dfy(366,6): Le1LoopCutDecomposeProb: Definition has `assume {:axiom}` statement in body. 
+src/Distributions/BernoulliExpNeg/Correctness.dfy(367,6): Le1LoopCutDecomposeProb: Definition has `assume {:axiom}` statement in body. 
+src/Distributions/BernoulliExpNeg/Correctness.dfy(374,6): Le1LoopCutDecomposeProb: Definition has `assume {:axiom}` statement in body. 
+src/Distributions/BernoulliExpNeg/Correctness.dfy(375,6): Le1LoopCutDecomposeProb: Definition has `assume {:axiom}` statement in body. 
+src/Distributions/BernoulliExpNeg/Correctness.dfy(379,6): Le1LoopCutDecomposeProb: Definition has `assume {:axiom}` statement in body. 
+src/Distributions/BernoulliExpNeg/Correctness.dfy(380,6): Le1LoopCutDecomposeProb: Definition has `assume {:axiom}` statement in body. 
+src/Distributions/BernoulliExpNeg/Correctness.dfy(570,8): Le1LoopCorrectnessEq: Definition has `assume {:axiom}` statement in body. 
+src/Distributions/BernoulliExpNeg/Correctness.dfy(571,8): Le1LoopCorrectnessEq: Definition has `assume {:axiom}` statement in body. 
 src/Distributions/BernoulliExpNeg/Model.dfy(112,10): Le1LoopTerminatesAlmostSurely: Definition has `assume {:axiom}` statement in body. 
 src/Distributions/BernoulliExpNeg/Model.dfy(148,4): Le1LoopDivergenceProbabilityBound: Definition has `assume {:axiom}` statement in body. 
 src/Distributions/BernoulliExpNeg/Model.dfy(161,8): Le1LoopDivergenceProbabilityBound: Definition has `assume {:axiom}` statement in body. 
@@ -20,12 +21,12 @@ src/Distributions/DiscreteLaplace/Correctness.dfy(37,17): Correctness: Declarati
 src/Distributions/DiscreteLaplace/Model.dfy(89,17): SampleInnerLoopTerminatesAlmostSurely: Declaration has explicit `{:axiom}` attribute. 
 src/Distributions/DiscreteLaplace/Model.dfy(93,17): SampleLoopTerminatesAlmostSurely: Declaration has explicit `{:axiom}` attribute. 
 src/Distributions/UniformPowerOfTwo/Implementation.dfy(42,6): UniformPowerOfTwoSample: Definition has `assume {:axiom}` statement in body. 
-src/Math/Analysis/Limits.dfy(116,17): Sandwich: Declaration has explicit `{:axiom}` attribute. 
+src/Math/Analysis/Limits.dfy(126,17): Sandwich: Declaration has explicit `{:axiom}` attribute. 
 src/Math/Analysis/Reals.dfy(35,17): LeastUpperBoundProperty: Declaration has explicit `{:axiom}` attribute. 
-src/Math/Exponential.dfy(11,17): EvalOne: Declaration has explicit `{:axiom}` attribute. 
-src/Math/Exponential.dfy(2,26): Exp: Declaration has explicit `{:axiom}` attribute. 
-src/Math/Exponential.dfy(4,17): FunctionalEquation: Declaration has explicit `{:axiom}` attribute. 
-src/Math/Exponential.dfy(7,17): Increasing: Declaration has explicit `{:axiom}` attribute. 
+src/Math/Exponential.dfy(49,17): ExpSeriesConverges: Declaration has explicit `{:axiom}` attribute. 
+src/Math/Exponential.dfy(52,17): FunctionalEquation: Declaration has explicit `{:axiom}` attribute. 
+src/Math/Exponential.dfy(55,17): Increasing: Declaration has explicit `{:axiom}` attribute. 
+src/Math/Exponential.dfy(59,17): EvalOne: Declaration has explicit `{:axiom}` attribute. 
 src/Math/Measures.dfy(125,17): ProbabilityLe1: Declaration has explicit `{:axiom}` attribute. 
 src/Math/Measures.dfy(130,17): IsMonotonic: Declaration has explicit `{:axiom}` attribute. 
 src/ProbabilisticProgramming/Independence.dfy(105,17): BindIsIndep: Declaration has explicit `{:axiom}` attribute. 

--- a/src/Math/Analysis/Limits.dfy
+++ b/src/Math/Analysis/Limits.dfy
@@ -93,6 +93,16 @@ module Limits {
     }
   }
 
+  // This would be trivial if Dafny had function extensionality
+  lemma LimitOfEqualsIsEqual(sequence1: nat -> real, sequence2: nat -> real, limit: real)
+    requires forall n: nat :: sequence1(n) == sequence2(n)
+    requires ConvergesTo(sequence1, limit)
+    ensures ConvergesTo(sequence2, limit)
+  {
+    assert Sequences.IsSuffixOf(sequence2, sequence1, 0);
+    SuffixConvergesToSame(sequence1, sequence2, 0, limit);
+  }
+
   lemma SuffixConvergesToSame(sequence: nat -> real, suffix: nat -> real, prefix: nat, limit: real)
     requires Sequences.IsSuffixOf(suffix, sequence, prefix)
     ensures ConvergesTo(suffix, limit) <==> ConvergesTo(sequence, limit)

--- a/src/Math/Measures.dfy
+++ b/src/Math/Measures.dfy
@@ -146,6 +146,17 @@ module Measures {
     }
   }
 
+  lemma MeasureOfCountableDisjointUnionIsSum<T(!new)>(eventSpace: iset<iset<T>>, mu: iset<T> -> real, parts: nat -> iset<T>, muParts: nat -> real)
+    requires IsMeasure(eventSpace, mu)
+    requires forall n: nat :: parts(n) in eventSpace
+    requires PairwiseDisjoint(parts)
+    requires forall n: nat :: muParts(n) == mu(parts(n))
+    ensures Series.SumsTo(muParts, mu(CountableUnion(parts)))
+  {
+    assert Series.SumsTo((n: nat) => mu(parts(n)), mu(CountableUnion(parts)));
+    Series.SumOfEqualsIsEqual((n: nat) => mu(parts(n)), muParts, mu(CountableUnion(parts)));
+  }
+
   // Equation (2.18)
   lemma PosCountAddImpliesAdd<T(!new)>(eventSpace: iset<iset<T>>, Prob: iset<T> -> real)
     requires IsSigmaAlgebra(eventSpace)


### PR DESCRIPTION
This finishes the "interesting" parts of the correctness proof of BernoulliExpNeg.

The following unproven assumptions are left in the proof:
- assuming measurability of some sets occurring in the proof
- assuming independence of `Hurd<A>` values
- assuming properties about the exponential functions and its series

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).
